### PR TITLE
Add support for extending existing filters

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -127,6 +127,17 @@ defmodule ElixirDruid.Query do
 	ordering: ordering}
     end
   end
+  defp build_filter(expression) do
+    # Anything else - it's probably a map coming from an existing
+    # filter.  Let's match on it at run time.
+    quote do
+      case unquote(expression) do
+	%{type: _} = filter ->
+	  # Looks like a filter!
+	  filter
+      end
+    end
+  end
 
   # TODO: handle dimension specs + extraction functions, not just "plain" dimensions
   defp maybe_build_dimension({{:., _, [{:dimensions, _, _}, dimension]}, _, _}) do

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -156,4 +156,22 @@ defmodule ElixirDruidTest do
                                   "ordering" => "lexicographic"}
   end
 
+  test "add extra filter to existing query" do
+    query = ElixirDruid.Query.build "timeseries", "my_datasource",
+      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+      filter: dimensions.foo == "bar"
+    query = ElixirDruid.Query.set query,
+      filter: dimensions.bar == "baz" and query.filter
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    assert decoded["filter"] == %{"type" => "and",
+                                  "fields" =>
+                                    [%{"type" => "selector",
+                                       "dimension" => "bar",
+                                       "value" => "baz"},
+                                     %{"type" => "selector",
+                                       "dimension" => "foo",
+                                       "value" => "bar"}]}
+  end
 end


### PR DESCRIPTION
Let's assume that anything unexpected in the filter specification is
a filter we've created earlier, and want to reuse.