### PR TITLE
Support date and datetime structs in query intervals

### DIFF
--- a/lib/elixir_druid.ex
+++ b/lib/elixir_druid.ex
@@ -97,4 +97,23 @@ defmodule ElixirDruid do
       end
     {:error, %ElixirDruid.Error{message: message}}
   end
+
+  @doc ~S"""
+  Format a date or a datetime into a format that Druid expects.
+
+  ## Examples
+
+      iex> ElixirDruid.format_time! ~D[2018-07-20]
+      "2018-07-20"
+      iex> ElixirDruid.format_time!(
+      ...>   Timex.to_datetime({{2018,07,20},{1,2,3}}))
+      "2018-07-20T01:02:03+00:00"
+  """
+  def format_time!(%DateTime{} = datetime) do
+    Timex.format! datetime, "{ISO:Extended}"
+  end
+  def format_time!(%Date{} = date) do
+    Timex.format! date, "{ISOdate}"
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule ElixirDruid.MixProject do
     [
       {:jason, "~> 1.1"},
       {:httpoison, "~> 1.0"},
+      {:timex, "~> 3.1"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.15.0", "40a2b8ce33a80ced7727e36768499fc9286881c43ebafccae6bab731e2b2b8ce", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.13.0", "24edc8cd2b28e1c652593833862435c80661834f6c9344e84b6a2255e7aeef03", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.2", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.2.0", "2702ed3da5fd7a8130fc34b11965c8cfa21ade2f232c00b42d96d4967c39a3a3", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.2", "e21cb58a09f0228a9e0b95eaa1217f1bcfc31a1aaa6e1fdf2f53a33f7dbd9494", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
@@ -8,5 +10,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "timex": {:hex, :timex, "3.3.0", "e0695aa0ddb37d460d93a2db34d332c2c95a40c27edf22fbfea22eb8910a9c8d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.17", "50793e3d85af49736701da1a040c415c97dc1caf6464112fd9bd18f425d3053b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -339,4 +339,32 @@ defmodule ElixirDruidTest do
              "analysisTypes" => ["cardinality", "minmax"]} == decoded
   end
 
+  test "build a query using date structs" do
+    query = ElixirDruid.Query.build "timeseries", "my_datasource",
+      intervals: [{~D[2018-05-29], ~D[2018-06-05]}],
+      granularity: :day
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    assert %{"queryType" => "timeseries",
+             "dataSource" => "my_datasource",
+             "granularity" => "day",
+             "intervals" => ["2018-05-29/2018-06-05"]} == decoded
+  end
+
+  test "build a query using datetime structs" do
+    from = Timex.to_datetime {{2018, 5, 29}, {1, 30, 0}}
+    to = Timex.to_datetime {{2018, 6, 5}, {18, 0, 0}}
+    query = ElixirDruid.Query.build "timeseries", "my_datasource",
+      intervals: [{from, to}],
+      granularity: :day
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    assert %{"queryType" => "timeseries",
+             "dataSource" => "my_datasource",
+             "intervals" => ["2018-05-29T01:30:00+00:00/2018-06-05T18:00:00+00:00"],
+             "granularity" => "day"} == decoded
+  end
+
 end


### PR DESCRIPTION
The Timex library seems to be the most sensible choice for formatting
them.