### PR TITLE
Handle filter fragment extracted from JSON object

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -270,6 +270,9 @@ defmodule ElixirDruid.Query do
 	%{type: _} = filter ->
 	  # Looks like a filter!
 	  filter
+        %{"type" => _} = filter ->
+          # Same, but the keys are strings, not atoms
+          filter
         nil ->
           # nil is a valid filter as well
           nil

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -256,6 +256,22 @@ defmodule ElixirDruidTest do
     end
   end
 
+  test "extract filter from JSON object" do
+    query = from "my_datasource",
+      query_type: "timeseries",
+      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+      filter: dimensions.foo == "bar"
+    json = ElixirDruid.Query.to_json(query)
+    %{"filter" => filter} = Jason.decode! json
+    new_query = from "my_datasource",
+      query_type: "timeseries",
+      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+      filter: ^filter
+    assert %{"filter" => %{"type" => "selector",
+                           "dimension" => "foo",
+                           "value" => "bar"}} = Jason.decode! ElixirDruid.Query.to_json new_query
+  end
+
   test "build a topN query" do
     query = from "my_datasource",
       query_type: "topN",


### PR DESCRIPTION
In this case, the keys will be strings instead of atoms.