### PR TITLE
Default 'intervals' to nil, not the empty list

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -1,5 +1,5 @@
 defmodule ElixirDruid.Query do
-  defstruct [query_type: nil, data_source: nil, intervals: [], granularity: nil,
+  defstruct [query_type: nil, data_source: nil, intervals: nil, granularity: nil,
 	     aggregations: nil, post_aggregations: nil, filter: nil,
              dimension: nil, dimensions: nil, metric: nil, threshold: nil, context: nil,
              to_include: nil, merge: nil, analysis_types: nil, limit_spec: nil]


### PR DESCRIPTION
We need this for 'timeBoundary' queries: they're not supposed to have
an interval.  If we pass an empty list of intervals, we get an empty
list back from Druid.