### PR TITLE
Support 'expression' filters

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -262,6 +262,14 @@ defmodule ElixirDruid.Query do
 	ordering: ordering}
     end
   end
+  defp build_filter({:expression, _, [expression]}) do
+    # A math expression, as described in http://druid.io/docs/0.12.1/misc/math-expr
+    # We're expecting a string that we're passing on to Druid
+    quote bind_quoted: [expression: expression] do
+      %{type: "expression",
+        expression: expression}
+    end
+  end
   defp build_filter({:^, _, [expression]}) do
     # We're recycling the ^ operator to incorporate an already created
     # filter into a filter expression.

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -194,6 +194,18 @@ defmodule ElixirDruidTest do
                                   "ordering" => "lexicographic"}
   end
 
+  test "build query with an 'expression' filter" do
+    query = from "my_datasource",
+      query_type: "timeseries",
+      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+      filter: expression("foo / 1000 < bar")
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    assert decoded["filter"] == %{"type" => "expression",
+                                  "expression" => "foo / 1000 < bar"}
+  end
+
   test "add extra filter to existing query" do
     query = from "my_datasource",
       query_type: "timeseries",


### PR DESCRIPTION
As described in http://druid.io/docs/0.12.1/misc/math-expr .

This should make some Druid queries much simpler.