### PR TITLE
Add configuration option for Druid request timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,7 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :elixir_druid,
+  request_timeout: 120_000,
   broker_profiles: [
     default: [
       base_url: "http://localhost:9088",

--- a/lib/elixir_druid.ex
+++ b/lib/elixir_druid.ex
@@ -60,7 +60,7 @@ defmodule ElixirDruid do
   end
 
   defp http_options(url, broker_profile) do
-    ssl_options(url, broker_profile) ++ auth_options(broker_profile)
+    ssl_options(url, broker_profile) ++ auth_options(broker_profile) ++ timeout_options()
   end
 
   defp ssl_options(url, broker_profile) do
@@ -79,6 +79,12 @@ defmodule ElixirDruid do
     else
       []
     end
+  end
+
+  defp timeout_options() do
+    # Default to 120 seconds
+    request_timeout = Application.get_env(:elixir_druid, :request_timeout, 120_000)
+    [recv_timeout: request_timeout]
   end
 
   defp maybe_handle_druid_error(


### PR DESCRIPTION
Default to 120 seconds, like the old querytool.