### PR TITLE
Pass request timeout in Druid query context

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -11,7 +11,15 @@ defmodule ElixirDruid.Query do
         case source do
           datasource when is_binary(datasource) ->
             # Are we creating a new query from scratch, given a datasource?
-            %ElixirDruid.Query{data_source: datasource}
+            #
+            # Let's add a timeout in the query "context", as we need to
+            # tell Druid to cancel the query if it takes too long.
+            # We're going to close the HTTP connection on our end, so
+            # there is no point in Druid keeping processing.
+            timeout = Application.get_env(:elixir_druid, :request_timeout, 120_000)
+            %ElixirDruid.Query{
+              data_source: datasource,
+              context: %{timeout: timeout}}
           %ElixirDruid.Query{} ->
             # Or are we extending an existing query?
             source

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -408,7 +408,8 @@ defmodule ElixirDruidTest do
              "dataSource" => "my_datasource",
              "toInclude" => %{"type" => "all"},
              "merge" => true,
-             "analysisTypes" => ["cardinality", "minmax"]} == decoded
+             "analysisTypes" => ["cardinality", "minmax"],
+             "context" => %{"timeout" => 120_000}} == decoded
   end
 
   test "build a segmentMetadata query limited to certain columns" do
@@ -426,7 +427,8 @@ defmodule ElixirDruidTest do
              "dataSource" => "my_datasource",
              "toInclude" => %{"type" => "list", "columns" => ["foo", "bar"]},
              "merge" => true,
-             "analysisTypes" => ["cardinality", "minmax"]} == decoded
+             "analysisTypes" => ["cardinality", "minmax"],
+             "context" => %{"timeout" => 120_000}} == decoded
   end
 
   test "build a query using date structs" do
@@ -440,7 +442,8 @@ defmodule ElixirDruidTest do
     assert %{"queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
-             "intervals" => ["2018-05-29/2018-06-05"]} == decoded
+             "intervals" => ["2018-05-29/2018-06-05"],
+             "context" => %{"timeout" => 120_000}} == decoded
   end
 
   test "build a query using datetime structs" do
@@ -456,7 +459,8 @@ defmodule ElixirDruidTest do
     assert %{"queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "intervals" => ["2018-05-29T01:30:00+00:00/2018-06-05T18:00:00+00:00"],
-             "granularity" => "day"} == decoded
+             "granularity" => "day",
+             "context" => %{"timeout" => 120_000}} == decoded
   end
 
 end


### PR DESCRIPTION
This way, Druid should cancel the query around the same time we give up waiting for it.