### PR TITLE
Handle 'nil' filter on aggregator

### DIFF
--- a/lib/elixir_druid/query.ex
+++ b/lib/elixir_druid/query.ex
@@ -101,10 +101,19 @@ defmodule ElixirDruid.Query do
   defp build_aggregation({name, {:when, _, [aggregation, filter]}}) do
     # XXX: is it correct to put the name on the "inner" aggregation,
     # instead of the filtered one?
-    quote do
-      %{type: "filtered",
-        filter: unquote(build_filter(filter)),
-        aggregator: unquote(build_aggregation({name, aggregation}))}
+    quote generated: true, bind_quoted: [
+      filter: build_filter(filter),
+      aggregator: build_aggregation({name, aggregation})]
+      do
+      case filter do
+        nil ->
+          # There is no filter - just use the plain aggregator
+          aggregator
+        _ ->
+          %{type: "filtered",
+            filter: filter,
+            aggregator: aggregator}
+      end
     end
   end
 

--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -57,6 +57,26 @@ defmodule ElixirDruidTest do
     #IO.puts json
   end
 
+  test "builds a query with a filtered aggregation, but the filter is nil" do
+    my_filter = nil
+    query = from "my_datasource",
+      query_type: "timeseries",
+      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+      granularity: :day,
+      aggregations: [
+        interesting_event_count: count() when ^my_filter
+      ]
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    # In this case, there is no need to add a filter to the aggregator
+    assert decoded["aggregations"] == [
+      %{"name" => "interesting_event_count",
+        "type" => "count"}
+    ]
+    # IO.puts json
+  end
+
   test "set an aggregation after building the query" do
     query = from "my_datasource",
       query_type: "timeseries",


### PR DESCRIPTION
Allow keeping an optional filter in a variable and then applying it to
an aggregator, without needing to check whether the filter is nil.