### PR TITLE
Allow certificate paths up to 10 levels deep

### DIFF
--- a/lib/elixir_druid.ex
+++ b/lib/elixir_druid.ex
@@ -66,7 +66,7 @@ defmodule ElixirDruid do
   defp ssl_options(url, broker_profile) do
     if url =~ ~r(^https://) do
       cacertfile = broker_profile[:cacertfile]
-      [ssl: [verify: :verify_peer, cacertfile: cacertfile]]
+      [ssl: [verify: :verify_peer, cacertfile: cacertfile, depth: 10]]
     else
       []
     end


### PR DESCRIPTION
**Problem:**
Segment cluster's SSL cert has a long path which isn't validated by default:
> Sep 13 16:07:07 live-segments-new-query-tool-1 Elixir: 2018-09-13 15:07:07.644 [info]  gadruidquery@127.0.0.1  ['TLS', 32, 'client', 58, 32, 73, 110, 32, 115, 116, 97, 116, 101, 32, 'certify', 32, 'at ssl_handshake.erl:1335 generated CLIENT ALERT: Fatal - Handshake Failure - {bad_cert,max_path_length_reached}', 10]
> Sep 13 16:07:07 live-segments-new-query-tool-1 Elixir: 2018-09-13 15:07:07.645 [error] gadruidquery@127.0.0.1  Druid request failure: {:tls_alert, 'handshake failure'}

See https://github.com/GameAnalytics/gaquery/pull/85/files for reference.

**Solution:**
Allow SSL certificate paths up to 10 levels deep.