### PR TITLE
Support 'bound' parameter

### DIFF
--- a/test/elixir_druid_test.exs
+++ b/test/elixir_druid_test.exs
@@ -509,4 +509,16 @@ defmodule ElixirDruidTest do
              "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
   end
 
+  test "build a timeBoundary query with a 'maxTime' bound" do
+    query = from "my_datasource",
+      query_type: "timeBoundary",
+      bound: :maxTime
+    json = ElixirDruid.Query.to_json(query)
+    assert is_binary(json)
+    decoded = Jason.decode! json
+    assert %{"queryType" => "timeBoundary",
+             "dataSource" => "my_datasource",
+             "bound" => "maxTime",
+             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+  end
 end


### PR DESCRIPTION
This way, we can make `timeBoundary` queries that ask for either `minTime` or `maxTime`, not both.