### PR TITLE
Configure Travis to publish to Hex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,11 @@ before_cache:
 cache:
   directories:
   - _build/dev
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  skip_cleanup: true
+  script:
+    - mix hex.publish --yes
+  on:
+    tags: true


### PR DESCRIPTION
travis will now publish the package to hex when we create a tag