### PR TITLE
Expose request_and_decode function as a fallback for missing features

### DIFF
--- a/lib/panoramix.ex
+++ b/lib/panoramix.ex
@@ -113,7 +113,7 @@ defmodule Panoramix do
     end
   end
 
-  defp request_and_decode(profile, method, url_path, body, headers) do
+  def request_and_decode(profile, method, url_path, body, headers) do
     broker_profiles = Application.get_env(:panoramix, :broker_profiles)
     broker_profile = broker_profiles[profile] ||
       raise ArgumentError, "no broker profile with name #{profile}"


### PR DESCRIPTION
We noticed that panoramix doesn't yet support [query datasources](https://druid.apache.org/docs/latest/querying/datasource.html#query). I was initially going to add support, but that's likely a larger side-quest than we're willing to invest in at this point. An alternative is to expose the underlying `request_and_decode` function so we can skip the DSL for queries that require unsupported syntax. 

We've written an alternative `post_query` method as follows

```
def post_map_query(map_query) do
  body = Jason.encode!(map_query)
  url_path = "/druid/v2"
  headers = [{"Content-Type", "application/json"}]

  Panoramix.request_and_decode(:default, :post, url_path, body, headers)
end
```

It would be nice to add this fallback directly to parnomix. That would help isolate the consumer from this low-level stuff, but I understand if that's not something your team is interested in so we went with just exposing `request_and_decode` in this pr. 