### PR TITLE
Allow passing JSON queries straight to Druid in post_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Response example:
  ]}
 ```
 
+You can also build a JSON query yourself by passing it as a map to
+`post_query`:
+
+```elixir
+Panoramix.post_query(%{queryType: "timeBoundary", dataSource: "my_datasource"})
+```
+
 ## Troubleshooting
 
 You can check correctness of your configuration by requesting status from Druid Broker. A successfull response will look like this.


### PR DESCRIPTION
This makes it possible to use any kind of query, regardless of whether
Panoramix has support for building and encoding it.