### PR TITLE
Use "generated: true" when incorporating filters

### DIFF
--- a/lib/panoramix/query.ex
+++ b/lib/panoramix/query.ex
@@ -493,7 +493,7 @@ defmodule Panoramix.Query do
   defp build_filter({:^, _, [expression]}) do
     # We're recycling the ^ operator to incorporate an already created
     # filter into a filter expression.
-    quote bind_quoted: [expression: expression] do
+    quote generated: true, bind_quoted: [expression: expression] do
       case expression do
         %{type: _} = filter ->
           # Looks like a filter!


### PR DESCRIPTION
This avoids a Dialyzer error when Dialyzer knows the type of the
filter, and thus knows that two of the case clauses are unused.