### PR TITLE
Combine "and" filters in more cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: elixir
 elixir:
-  - 1.8
-  - 1.9
-otp_release: '21.0'
+  - 1.12.3
+otp_release: '22.3.4'
 script:
     - mix compile --warnings-as-errors
     - mix test

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Panoramix.MixProject do
     [
       app: :panoramix,
       version: System.cmd("git", ["describe", "--tags"]) |> elem(0) |> String.trim_trailing |> String.trim_leading("v"),
-      elixir: "~> 1.8",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       description: "Client library for sending requests to Druid.",
       source_url: "https://github.com/GameAnalytics/panoramix",


### PR DESCRIPTION
If part of the filter uses string keys (e.g. if it was parsed from
JSON), make sure we're still combining adjacent "and" filters for
tidier queries.