### PR TITLE
Add `subtotals_spec` and support variables on aggregations

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,11 @@
-# Used by "mix format"
+locals_without_parens = [
+  from: 2
+]
+
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,9 +34,9 @@ config :panoramix,
   query_priority: 0,
   broker_profiles: [
     default: [
-      base_url:       "https://druid-broker-host:9088",
-      cacertfile:     "path/to/druid-certificate.crt",
-      http_username:  "username",
-      http_password:  "password"
+      base_url: "https://druid-broker-host:9088",
+      cacertfile: "path/to/druid-certificate.crt",
+      http_username: "username",
+      http_password: "password"
     ]
   ]

--- a/lib/panoramix/query.ex
+++ b/lib/panoramix/query.ex
@@ -2,12 +2,29 @@ defmodule Panoramix.Query do
   @moduledoc """
   Provides functions for building Druid query requests.
   """
-  defstruct [query_type: nil, data_source: nil, intervals: nil, granularity: nil,
-             aggregations: nil, post_aggregations: nil, filter: nil,
-             dimension: nil, dimensions: nil, metric: nil, threshold: nil, context: nil,
-             to_include: nil, merge: nil, analysis_types: nil, limit_spec: nil,
-             bound: nil, virtual_columns: nil, limit: nil, search_dimensions: nil,
-             query: nil, sort: nil]
+
+  defstruct aggregations: nil,
+            analysis_types: nil,
+            bound: nil,
+            context: nil,
+            data_source: nil,
+            dimension: nil,
+            dimensions: nil,
+            filter: nil,
+            granularity: nil,
+            intervals: nil,
+            limit: nil,
+            limit_spec: nil,
+            merge: nil,
+            metric: nil,
+            post_aggregations: nil,
+            query: nil,
+            search_dimensions: nil,
+            sort: nil,
+            threshold: nil,
+            to_include: nil,
+            virtual_columns: nil,
+            query_type: nil
 
   # A query has type Panoramix.query.t()
   @type t :: %__MODULE__{}
@@ -29,31 +46,31 @@ defmodule Panoramix.Query do
       ...(2)>        aggregations: [event_count: count(),
       ...(2)>                       unique_id_count: hyperUnique(:user_unique)]
       %Panoramix.Query{
-      aggregations: [
-        %{name: :event_count, type: "count"},
-        %{fieldName: :user_unique, name: :unique_id_count, type: :hyperUnique}
-      ],
-      analysis_types: nil,
-      bound: nil,
-      context: %{priority: 0, timeout: 120000},
-      data_source: "my_datasource",
-      dimension: nil,
-      dimensions: nil,
-      filter: %{dimension: "foo", type: "selector", value: "bar"},
-      granularity: :day,
-      intervals: ["2019-03-01T00:00:00+00:00/2019-03-04T00:00:00+00:00"],
-      limit: nil,
-      limit_spec: nil,
-      merge: nil,
-      metric: nil,
-      post_aggregations: nil,
-      query: nil,
-      query_type: "timeseries",
-      search_dimensions: nil,
-      sort: nil,
-      threshold: nil,
-      to_include: nil,
-      virtual_columns: nil
+        aggregations: [
+          %{name: :event_count, type: "count"},
+          %{fieldName: :user_unique, name: :unique_id_count, type: :hyperUnique}
+        ],
+        analysis_types: nil,
+        bound: nil,
+        context: %{priority: 0, timeout: 120000},
+        data_source: "my_datasource",
+        dimension: nil,
+        dimensions: nil,
+        filter: %{dimension: "foo", type: "selector", value: "bar"},
+        granularity: :day,
+        intervals: ["2019-03-01T00:00:00+00:00/2019-03-04T00:00:00+00:00"],
+        limit: nil,
+        limit_spec: nil,
+        merge: nil,
+        metric: nil,
+        post_aggregations: nil,
+        query: nil,
+        query_type: "timeseries",
+        search_dimensions: nil,
+        sort: nil,
+        threshold: nil,
+        to_include: nil,
+        virtual_columns: nil,
       }
     ```
 
@@ -95,17 +112,20 @@ defmodule Panoramix.Query do
     # we always have some to work with. If these have already been supplied
     # in kw then defaults will be overwritten.
     query_fields = [context: default_context()] ++ List.foldl(kw, [], &build_query/2)
+
     quote generated: true, bind_quoted: [source: source, query_fields: query_fields] do
       query =
         case source do
           %Panoramix.Query{} ->
             # Are we extending an existing query?
             source
+
           _ ->
             # Are we creating a new query from scratch, given some kind of datasource?
             %Panoramix.Query{data_source: Panoramix.Query.datasource(source)}
         end
-      Map.merge(query, Map.new query_fields)
+
+      Map.merge(query, Map.new(query_fields))
     end
   end
 
@@ -115,18 +135,22 @@ defmodule Panoramix.Query do
     # We're using a named datasource as the source for the query
     datasource
   end
+
   def datasource(%{type: :query, query: nested_query} = datasource) do
     # The datasource is a nested query. Let's convert it to JSON if needed
     nested_query_json =
       case nested_query do
         %Panoramix.Query{} ->
           to_map(nested_query)
+
         _ ->
           # Assume it's already JSON-shaped
           nested_query
       end
+
     %{datasource | query: nested_query_json}
   end
+
   def datasource(%{type: :join, left: left, right: right} = datasource) do
     # A join between two datasources.
     # A named datasource and a recursive join can only appear on the
@@ -135,6 +159,7 @@ defmodule Panoramix.Query do
     right_datasource = datasource(right)
     %{datasource | left: left_datasource, right: right_datasource}
   end
+
   def datasource(%{type: type} = datasource) when is_atom(type) do
     # Some other type of datasource. Let's include it literally.
     datasource
@@ -155,194 +180,237 @@ defmodule Panoramix.Query do
   end
 
   defp build_query({field, value}, query_fields)
-  when field in [:granularity, :dimension, :dimensions, :metric, :query_type,
-                 :threshold, :merge, :analysis_types, :limit_spec,
-                 :limit, :search_dimensions, :query, :sort] do
+       when field in [
+              :granularity,
+              :dimension,
+              :dimensions,
+              :metric,
+              :query_type,
+              :threshold,
+              :merge,
+              :analysis_types,
+              :limit_spec,
+              :limit,
+              :search_dimensions,
+              :query,
+              :sort
+            ] do
     # For these fields, we just include the value verbatim.
     [{field, value}] ++ query_fields
   end
+
   defp build_query({:bound, bound}, query_fields) do
-    [bound:
-     quote generated: true, bind_quoted: [bound: bound] do
-       value = String.Chars.to_string bound
-       unless value in ["maxTime", "minTime"] do
-         raise ArgumentError, "invalid bound value '#{value}', expected 'maxTime' or 'minTime'"
-       end
-       value
-     end
+    [
+      bound:
+        quote generated: true, bind_quoted: [bound: bound] do
+          value = String.Chars.to_string(bound)
+
+          unless value in ["maxTime", "minTime"] do
+            raise ArgumentError, "invalid bound value '#{value}', expected 'maxTime' or 'minTime'"
+          end
+
+          value
+        end
     ] ++ query_fields
   end
+
   defp build_query({:intervals, intervals}, query_fields) do
     [intervals: build_intervals(intervals)] ++ query_fields
   end
+
   defp build_query({:aggregations, aggregations}, query_fields) do
     [aggregations: build_aggregations(aggregations)] ++ query_fields
   end
+
   defp build_query({:post_aggregations, post_aggregations}, query_fields) do
     [post_aggregations: build_post_aggregations(post_aggregations)] ++ query_fields
   end
+
   defp build_query({:filter, filter}, query_fields) do
     [filter: build_filter(filter)] ++ query_fields
   end
+
   defp build_query({:to_include, to_include}, query_fields) do
-    [to_include:
-     quote do
-         case unquote(to_include) do
-           :all ->
-             %{type: "all"}
-           :none ->
-             %{type: "none"}
-           list when is_list(list) ->
-             %{type: "list", columns: list}
-         end
-     end] ++ query_fields
+    [
+      to_include:
+        quote do
+          case unquote(to_include) do
+            :all ->
+              %{type: "all"}
+
+            :none ->
+              %{type: "none"}
+
+            list when is_list(list) ->
+              %{type: "list", columns: list}
+          end
+        end
+    ] ++ query_fields
   end
+
   defp build_query({:virtual_columns, virtual_columns}, query_fields) do
     [virtual_columns: build_virtual_columns(virtual_columns)] ++ query_fields
   end
+
   defp build_query({:context, context}, query_fields) do
     [context: build_context(context)] ++ query_fields
   end
+
   defp build_query({unknown, _}, _query_fields) do
-    raise ArgumentError, "Unknown query field #{inspect unknown}"
+    raise ArgumentError, "Unknown query field #{inspect(unknown)}"
   end
 
   defp build_intervals(intervals) do
     # mark as "generated" to avoid warnings about unreachable case
     # clauses when interval is a constant
     quote generated: true, bind_quoted: [intervals: intervals] do
-      Enum.map intervals, fn
+      Enum.map(intervals, fn
         interval_string when is_binary(interval_string) ->
           # Already a string - pass it on unchanged
           interval_string
+
         {from, to} ->
           Panoramix.format_time!(from) <> "/" <> Panoramix.format_time!(to)
-      end
+      end)
     end
   end
 
   defp build_aggregations(aggregations) do
-    Enum.map aggregations, &build_aggregation/1
+    Enum.map(aggregations, &build_aggregation/1)
   end
 
   defp build_aggregation({name, {:count, _, []}}) do
-    quote do: %{type: "count", name: unquote name}
+    quote do: %{type: "count", name: unquote(name)}
   end
+
   defp build_aggregation({name, {:when, _, [aggregation, filter]}}) do
     # XXX: is it correct to put the name on the "inner" aggregation,
     # instead of the filtered one?
-    quote generated: true, bind_quoted: [
-      filter: build_filter(filter),
-      aggregator: build_aggregation({name, aggregation})]
-      do
+    quote generated: true,
+          bind_quoted: [
+            filter: build_filter(filter),
+            aggregator: build_aggregation({name, aggregation})
+          ] do
       case filter do
         nil ->
           # There is no filter - just use the plain aggregator
           aggregator
+
         _ ->
-          %{type: "filtered",
-            filter: filter,
-            aggregator: aggregator}
+          %{type: "filtered", filter: filter, aggregator: aggregator}
       end
     end
   end
+
   defp build_aggregation({name, {aggregation_type, _, [field_name]}}) do
     # e.g. hyperUnique(:user_unique)
     normalized_aggregation_type = normalize_aggregation_type_name(aggregation_type)
-    quote do: %{type: unquote(normalized_aggregation_type),
-        name: unquote(name),
-        fieldName: unquote(field_name)}
+
+    quote do: %{
+            type: unquote(normalized_aggregation_type),
+            name: unquote(name),
+            fieldName: unquote(field_name)
+          }
   end
+
   defp build_aggregation({name, {aggregation_type, _, [field_name, keywords]}}) do
     # e.g. hyperUnique(:user_unique, round: true)
     normalized_aggregation_type = normalize_aggregation_type_name(aggregation_type)
-    quote generated: true, bind_quoted: [
-      aggregation_type: normalized_aggregation_type,
-      name: name,
-      field_name: field_name,
-      keywords: keywords]
-      do
+
+    quote generated: true,
+          bind_quoted: [
+            aggregation_type: normalized_aggregation_type,
+            name: name,
+            field_name: field_name,
+            keywords: keywords
+          ] do
       Map.merge(
-        %{type: aggregation_type,
-          name: name,
-          fieldName: field_name},
-        Map.new(keywords))
+        %{type: aggregation_type, name: name, fieldName: field_name},
+        Map.new(keywords)
+      )
     end
   end
 
   # Some capitalized aggregation names need normalizing. See docs for more info.
-  defp normalize_aggregation_type_name(:hllSketchBuild), do:
-    "HLLSketchBuild"
-  defp normalize_aggregation_type_name(:hllSketchMerge), do:
-    "HLLSketchMerge"
-  defp normalize_aggregation_type_name(:hllSketchEstimate), do:
-    "HLLSketchEstimate"
-  defp normalize_aggregation_type_name(:hllSketchEstimateWithBounds), do:
-    "HLLSketchEstimateWithBounds"
-  defp normalize_aggregation_type_name(:hllSketchUnion), do:
-    "HLLSketchUnion"
-  defp normalize_aggregation_type_name(:hllSketchToString), do:
-    "HLLSketchToString"
-  defp normalize_aggregation_type_name(name), do:
-    name
+  defp normalize_aggregation_type_name(:hllSketchBuild), do: "HLLSketchBuild"
+  defp normalize_aggregation_type_name(:hllSketchMerge), do: "HLLSketchMerge"
+  defp normalize_aggregation_type_name(:hllSketchEstimate), do: "HLLSketchEstimate"
+
+  defp normalize_aggregation_type_name(:hllSketchEstimateWithBounds),
+    do: "HLLSketchEstimateWithBounds"
+
+  defp normalize_aggregation_type_name(:hllSketchUnion), do: "HLLSketchUnion"
+  defp normalize_aggregation_type_name(:hllSketchToString), do: "HLLSketchToString"
+  defp normalize_aggregation_type_name(name), do: name
 
   defp build_post_aggregations(post_aggregations) do
-    Enum.map post_aggregations,
-    fn {name, post_aggregation} ->
-      pa = build_post_aggregation(post_aggregation)
-      quote do
-        Map.put(unquote(pa), :name, unquote(name))
+    Enum.map(
+      post_aggregations,
+      fn {name, post_aggregation} ->
+        pa = build_post_aggregation(post_aggregation)
+
+        quote do
+          Map.put(unquote(pa), :name, unquote(name))
+        end
       end
-    end
+    )
   end
 
   defp build_post_aggregation({arith_op, _, [a, b]})
-  when arith_op in [:+, :-, :*, :/] do
+       when arith_op in [:+, :-, :*, :/] do
     pa1 = build_post_aggregation(a)
     pa2 = build_post_aggregation(b)
+
     quote do
-      %{type: "arithmetic",
-        fn: unquote(arith_op),
-        fields: [unquote(pa1), unquote(pa2)]}
+      %{type: "arithmetic", fn: unquote(arith_op), fields: [unquote(pa1), unquote(pa2)]}
     end
   end
+
   defp build_post_aggregation({{:., _, [{:aggregations, _, _}, aggregation]}, _, _}) do
     # aggregations.foo
     quote do
-      %{type: "fieldAccess",
-        fieldName: unquote(aggregation)}
+      %{type: "fieldAccess", fieldName: unquote(aggregation)}
     end
   end
+
   defp build_post_aggregation({{:., _, [Access, :get]}, _, [{:aggregations, _, _}, aggregation]}) do
     # aggregations["foo"]
     quote do
-      %{type: "fieldAccess",
-        fieldName: unquote(aggregation)}
+      %{type: "fieldAccess", fieldName: unquote(aggregation)}
     end
   end
+
   defp build_post_aggregation(constant) when is_number(constant) do
     quote do
-      %{type: "constant",
-        value: unquote(constant)}
+      %{type: "constant", value: unquote(constant)}
     end
   end
+
   defp build_post_aggregation({:expression, _, [expression]}) do
     {:%{}, [], [{:type, "expression"}, {:expression, expression}]}
   end
+
   defp build_post_aggregation({post_aggregator, _, [field | options]})
-  when post_aggregator in [:hllSketchToString, :hllSketchEstimateWithBounds, :hllSketchEstimate] do
+       when post_aggregator in [
+              :hllSketchToString,
+              :hllSketchEstimateWithBounds,
+              :hllSketchEstimate
+            ] do
     field_ref = build_post_aggregation(field)
     post_aggregation_field_accessor(post_aggregator, :field, field_ref, options)
   end
+
   defp build_post_aggregation({:hllSketchUnion, _, [fields | options]}) do
     pa_list = for field <- fields, do: build_post_aggregation(field)
     post_aggregation_field_accessor(:hllSketchUnion, :fields, pa_list, options)
   end
+
   defp build_post_aggregation({post_aggregator, _, [fields]})
-  when post_aggregator in [:doubleGreatest, :longGreatest, :doubleLeast, :longLeast] do
+       when post_aggregator in [:doubleGreatest, :longGreatest, :doubleLeast, :longLeast] do
     pa_list = for field <- fields, do: build_post_aggregation(field)
     post_aggregation_field_accessor(post_aggregator, :fields, pa_list)
   end
+
   defp build_post_aggregation({post_aggregator, _, [field_name | options]}) do
     # This is for all post-aggregators that use a "fieldName" parameter,
     # and optionally a bunch of extra parameters.
@@ -358,24 +426,30 @@ defmodule Panoramix.Query do
   defp build_filter({:== = operator, _, [a, b]}) do
     build_eq_filter(operator, a, b)
   end
+
   defp build_filter({:!= = operator, _, [a, b]}) do
     eq_filter = build_eq_filter(operator, a, b)
     {:%{}, [], [type: "not", field: eq_filter]}
   end
+
   defp build_filter({:and, _, [a, b]}) do
     filter_a = build_filter(a)
     filter_b = build_filter(b)
+
     quote generated: true do
       case {unquote(filter_a), unquote(filter_b)} do
         {nil, nil} ->
           # No filter AND no filter: that's "no filter"
           nil
+
         {nil, filter} ->
           # No filter AND filter: just one filter
           filter
+
         {filter, nil} ->
           # Likewise
           filter
+
         # If either or both filter is an AND already, merge them together
         {filter_a_unquoted, filter_b_unquoted} ->
           # Need to handle both atom and string keys
@@ -383,78 +457,106 @@ defmodule Panoramix.Query do
           b_is_and = unquote(atom_or_string_value(quote(do: filter_b_unquoted), :type)) == "and"
           filter_a_fields = unquote(atom_or_string_value(quote(do: filter_a_unquoted), :fields))
           filter_b_fields = unquote(atom_or_string_value(quote(do: filter_b_unquoted), :fields))
+
           case {a_is_and, b_is_and} do
             {true, true} ->
               %{type: "and", fields: filter_a_fields ++ filter_b_fields}
+
             {true, false} ->
               %{type: "and", fields: filter_a_fields ++ [filter_b_unquoted]}
+
             {false, true} ->
               %{type: "and", fields: [filter_a_unquoted] ++ filter_b_fields}
+
             {false, false} ->
               %{type: "and", fields: [filter_a_unquoted, filter_b_unquoted]}
           end
       end
     end
   end
+
   defp build_filter({:or, _, [a, b]}) do
     filter_a = build_filter(a)
     filter_b = build_filter(b)
+
     quote generated: true do
       # It's not meaningful to use 'or' with the empty filter,
       # since the empty filter already allows anything.
       case {unquote(filter_a), unquote(filter_b)} do
         {nil, _} ->
           raise "left operand to 'or' must not be nil"
+
         {_, nil} ->
           raise "right operand to 'or' must not be nil"
+
         {filter_a_unquoted, filter_b_unquoted} ->
           %{type: "or", fields: [filter_a_unquoted, filter_b_unquoted]}
       end
     end
   end
+
   defp build_filter({:not, _, [a]}) do
     filter = build_filter(a)
+
     quote generated: true do
       # It's not meaningful to use 'not' with the empty filter,
       # since "not everything" would allow "nothing".
       case unquote(filter) do
         nil ->
           raise "operand to 'not' must not be nil"
+
         filter_unquoted ->
           %{type: "not", field: filter_unquoted}
       end
     end
   end
+
   # Let's handle the 'in' operator.  First, let's handle
   # dimensions.foo in intervals([a, b])
   # (where 'foo' will usually be '__time', a special dimension for
   # the event timestamp)
   defp build_filter({:in, _, [a, {:intervals, _, [intervals]}]}) do
     dimension = dimension_or_extraction_fn(a)
+
     unless dimension do
       raise "left operand of 'in' must be a dimension"
     end
-    {:%{}, [], [
-        type: "interval",
-        intervals: build_intervals(intervals)] ++
+
+    {
+      :%{},
+      [],
       # allow extraction function
-      Map.to_list(dimension)}
+      [
+        type: "interval",
+        intervals: build_intervals(intervals)
+      ] ++
+        Map.to_list(dimension)
+    }
   end
+
   # Now handle
   # dimensions.foo in ["123", "456"]
   defp build_filter({:in, _, [a, values]}) do
     dimension = dimension_or_extraction_fn(a)
+
     unless dimension do
       raise "left operand of 'in' must be a dimension"
     end
-    {:%{}, [], [
-        type: "in",
-        values: values] ++
+
+    {
+      :%{},
+      [],
       # allow extraction function
-      Map.to_list(dimension)}
+      [
+        type: "in",
+        values: values
+      ] ++
+        Map.to_list(dimension)
+    }
   end
+
   defp build_filter({lt1, _, [{lt2, _, [a, b]}, c]})
-    when lt1 in [:<, :<=] and lt2 in [:<, :<=] do
+       when lt1 in [:<, :<=] and lt2 in [:<, :<=] do
     # 1 < dimensions.foo < 10, or
     # 1 <= dimensions.foo <= 10
     #
@@ -462,15 +564,22 @@ defmodule Panoramix.Query do
     # ((a < b) < c)
     # so lt2 is actually the one that appears first in the
     # source code.
-    lower_strict = (lt2 == :<)
-    upper_strict = (lt1 == :<)
+    lower_strict = lt2 == :<
+    upper_strict = lt1 == :<
     dimension = dimension_or_extraction_fn(b)
+
     unless dimension do
       raise "middle operand in bound filter must be a dimension"
     end
-    base = {:%{}, [], [type: "bound", lowerStrict: lower_strict, upperStrict: upper_strict] ++
+
+    base = {
+      :%{},
+      [],
       # allow extraction function
-      Map.to_list(dimension)}
+      [type: "bound", lowerStrict: lower_strict, upperStrict: upper_strict] ++
+        Map.to_list(dimension)
+    }
+
     # Need 'generated: true' here to avoid compiler warnings for
     # our case expression in case a and c are literal constants.
     quote generated: true do
@@ -482,25 +591,29 @@ defmodule Panoramix.Query do
         case {unquote(a), unquote(c)} do
           {l, u} when is_integer(l) and is_integer(u) ->
             {Integer.to_string(l), Integer.to_string(u), "numeric"}
+
           {l, u} when is_float(l) and is_float(u) ->
             {Float.to_string(l), Float.to_string(u), "numeric"}
+
           {l, u} when is_binary(l) and is_binary(u) ->
             {l, u, "lexicographic"}
         end
-      Map.merge(unquote(base),
-        %{lower: lower,
-          upper: upper,
-          ordering: ordering})
+
+      Map.merge(
+        unquote(base),
+        %{lower: lower, upper: upper, ordering: ordering}
+      )
     end
   end
+
   defp build_filter({:expression, _, [expression]}) do
     # A math expression, as described in http://druid.io/docs/0.12.1/misc/math-expr
     # We're expecting a string that we're passing on to Druid
     quote bind_quoted: [expression: expression] do
-      %{type: "expression",
-        expression: expression}
+      %{type: "expression", expression: expression}
     end
   end
+
   defp build_filter({:^, _, [expression]}) do
     # We're recycling the ^ operator to incorporate an already created
     # filter into a filter expression.
@@ -509,9 +622,11 @@ defmodule Panoramix.Query do
         %{type: _} = filter ->
           # Looks like a filter!
           filter
+
         %{"type" => _} = filter ->
           # Same, but the keys are strings, not atoms
           filter
+
         nil ->
           # nil is a valid filter as well
           nil
@@ -522,24 +637,34 @@ defmodule Panoramix.Query do
   defp build_eq_filter(operator, a, b) do
     dimension_a = dimension_or_extraction_fn(a)
     dimension_b = dimension_or_extraction_fn(b)
+
     case {dimension_a, dimension_b} do
       {nil, _} ->
         raise "left operand of #{operator} must be a dimension"
+
       {_, nil} ->
         # Compare a dimension to a value
-        {:%{}, [], [
-            type: "selector",
-            value: b] ++
+        {
+          :%{},
+          [],
           # dimension_a is either just a dimension, or a dimension
           # plus an extraction function
-          Map.to_list(dimension_a)}
+          [
+            type: "selector",
+            value: b
+          ] ++
+            Map.to_list(dimension_a)
+        }
+
       {_, _} ->
         # Compare two dimensions
         dimension_spec_a = to_dimension_spec(dimension_a)
         dimension_spec_b = to_dimension_spec(dimension_b)
-        quote do: %{type: "columnComparison",
-                    dimensions: [unquote(dimension_spec_a),
-                                 unquote(dimension_spec_b)]}
+
+        quote do: %{
+                type: "columnComparison",
+                dimensions: [unquote(dimension_spec_a), unquote(dimension_spec_b)]
+              }
     end
   end
 
@@ -550,12 +675,18 @@ defmodule Panoramix.Query do
     # or nil if neither is present in the map.
     var = Macro.unique_var(:x, __MODULE__)
     key_string = Atom.to_string(key_atom)
-    {:case, [generated: true], [
-        map,
-        [do: [
-          {:->, [generated: true], [[{:%{}, [], [{key_atom, var}]}], var]},
-          {:->, [generated: true], [[{:%{}, [], [{key_string, var}]}], var]},
-          {:->, [generated: true], [[{:%{}, [], []}], nil]}]]]}
+
+    {:case, [generated: true],
+     [
+       map,
+       [
+         do: [
+           {:->, [generated: true], [[{:%{}, [], [{key_atom, var}]}], var]},
+           {:->, [generated: true], [[{:%{}, [], [{key_string, var}]}], var]},
+           {:->, [generated: true], [[{:%{}, [], []}], nil]}
+         ]
+       ]
+     ]}
   end
 
   # TODO: handle more extraction functions
@@ -563,76 +694,96 @@ defmodule Panoramix.Query do
     # dimensions.foo
     %{dimension: Atom.to_string(dimension)}
   end
+
   defp dimension_or_extraction_fn({{:., _, [Access, :get]}, _, [{:dimensions, _, _}, dimension]}) do
     # dimensions["foo"]
     %{dimension: dimension}
   end
+
   defp dimension_or_extraction_fn({:lookup, _, args}) do
     case args do
       [lookup_name | maybe_opts] ->
-        opts = case maybe_opts do
-                 [] -> []
-                 [opts] -> opts
-               end
-        %{extractionFn: {:%{}, [],
-                         [{"type", "registeredLookup"},
-                          {"lookup", lookup_name}] ++ opts}}
+        opts =
+          case maybe_opts do
+            [] -> []
+            [opts] -> opts
+          end
+
+        %{
+          extractionFn:
+            {:%{}, [], [{"type", "registeredLookup"}, {"lookup", lookup_name}] ++ opts}
+        }
+
       _ ->
         raise ArgumentError, "Expected lookup name as argument to lookup"
     end
   end
+
   defp dimension_or_extraction_fn({:|>, _, [left, right]}) do
     left = dimension_or_extraction_fn(left)
     right = dimension_or_extraction_fn(right)
+
     case {left, right} do
-      {%{dimension: dimension, extractionFn: left_extraction_fn}, %{extractionFn: right_extraction_fn}} ->
+      {%{dimension: dimension, extractionFn: left_extraction_fn},
+       %{extractionFn: right_extraction_fn}} ->
         # There are extraction functions on both sides of the operator
         # - let's combine them into a cascade extraction function.
-        %{dimension: dimension,
-          extractionFn: {:%{}, [],
-                         [{"type", "cascade"},
-                          {"extractionFns", [left_extraction_fn, right_extraction_fn]}]}}
+        %{
+          dimension: dimension,
+          extractionFn:
+            {:%{}, [],
+             [{"type", "cascade"}, {"extractionFns", [left_extraction_fn, right_extraction_fn]}]}
+        }
+
       {%{dimension: dimension}, %{extractionFn: extraction_fn}} ->
         %{dimension: dimension, extractionFn: extraction_fn}
     end
   end
+
   defp dimension_or_extraction_fn(_) do
     nil
   end
 
   defp to_dimension_spec(%{dimension: dimension, extractionFn: extraction_fn}) do
     # Do we need to set outputName here?
-    {:%{}, [], [type: "extraction",
-                dimension: dimension,
-                extractionFn: extraction_fn]}
+    {:%{}, [], [type: "extraction", dimension: dimension, extractionFn: extraction_fn]}
   end
+
   defp to_dimension_spec(%{dimension: dimension}) do
     dimension
   end
 
   defp build_virtual_columns(virtual_columns) do
-    Enum.map virtual_columns, &build_virtual_column/1
+    Enum.map(virtual_columns, &build_virtual_column/1)
   end
 
   defp build_virtual_column({name, {:expression, _, [expression, output_type]}}) do
-    quote generated: true, bind_quoted: [
-      name: name,
-      expression: expression,
-      output_type: output_type
-    ] do
+    quote generated: true,
+          bind_quoted: [
+            name: name,
+            expression: expression,
+            output_type: output_type
+          ] do
       output_type = String.upcase(String.Chars.to_string(output_type))
+
       unless output_type in ["LONG", "FLOAT", "DOUBLE", "STRING"] do
-        raise ArgumentError, "Unexpected output type #{output_type}, expected one of :long, :float, :double, :string"
+        raise ArgumentError,
+              "Unexpected output type #{output_type}, expected one of :long, :float, :double, :string"
       end
-      %{"type" => "expression",
+
+      %{
+        "type" => "expression",
         "name" => name,
         "outputType" => output_type,
-        "expression" => expression}
+        "expression" => expression
+      }
     end
   end
+
   defp build_virtual_column({_name, {:expression, _, args}}) do
-    raise ArgumentError, "Expected 2 arguments to 'expression' in virtual column, expression and output type; " <>
-      "got #{length args}"
+    raise ArgumentError,
+          "Expected 2 arguments to 'expression' in virtual column, expression and output type; " <>
+            "got #{length(args)}"
   end
 
   defp build_context(context) do
@@ -648,28 +799,30 @@ defmodule Panoramix.Query do
     unless query.query_type do
       raise "query type not specified"
     end
-    [queryType: query.query_type,
-     dataSource: query.data_source,
-     intervals: query.intervals,
-     granularity: query.granularity,
-     aggregations: query.aggregations,
-     postAggregations: query.post_aggregations,
-     filter: query.filter,
-     dimension: query.dimension,
-     dimensions: query.dimensions,
-     metric: query.metric,
-     threshold: query.threshold,
-     context: query.context,
-     toInclude: query.to_include,
-     merge: query.merge,
-     analysisTypes: query.analysis_types,
-     limitSpec: query.limit_spec,
-     bound: query.bound,
-     virtualColumns: query.virtual_columns,
-     limit: query.limit,
-     searchDimensions: query.search_dimensions,
-     query: query.query,
-     sort: query.sort,
+
+    [
+      queryType: query.query_type,
+      dataSource: query.data_source,
+      intervals: query.intervals,
+      granularity: query.granularity,
+      aggregations: query.aggregations,
+      postAggregations: query.post_aggregations,
+      filter: query.filter,
+      dimension: query.dimension,
+      dimensions: query.dimensions,
+      metric: query.metric,
+      threshold: query.threshold,
+      context: query.context,
+      toInclude: query.to_include,
+      merge: query.merge,
+      analysisTypes: query.analysis_types,
+      limitSpec: query.limit_spec,
+      bound: query.bound,
+      virtualColumns: query.virtual_columns,
+      limit: query.limit,
+      searchDimensions: query.search_dimensions,
+      query: query.query,
+      sort: query.sort
     ]
     |> Enum.reject(fn {_, v} -> is_nil(v) end)
     |> Enum.into(%{})
@@ -681,6 +834,6 @@ defmodule Panoramix.Query do
   def to_json(query) do
     query
     |> to_map()
-    |> Jason.encode!
+    |> Jason.encode!()
   end
 end

--- a/lib/panoramix/query.ex
+++ b/lib/panoramix/query.ex
@@ -22,12 +22,31 @@ defmodule Panoramix.Query do
             search_dimensions: nil,
             sort: nil,
             threshold: nil,
+            subtotals_spec: nil,
             to_include: nil,
             virtual_columns: nil,
             query_type: nil
 
   # A query has type Panoramix.query.t()
   @type t :: %__MODULE__{}
+
+  # For these fields, we just include the value verbatim.
+  @unmapped_query_fields [
+    :analysis_types,
+    :dimension,
+    :dimensions,
+    :granularity,
+    :limit,
+    :limit_spec,
+    :merge,
+    :metric,
+    :query,
+    :query_type,
+    :search_dimensions,
+    :sort,
+    :subtotals_spec,
+    :threshold
+  ]
 
   @doc """
   Use `from` macro to build Druid queries. See [Druid documentation](http://druid.io/docs/latest/querying/querying.html) to learn about
@@ -71,6 +90,7 @@ defmodule Panoramix.Query do
         threshold: nil,
         to_include: nil,
         virtual_columns: nil,
+        subtotals_spec: nil
       }
     ```
 
@@ -179,23 +199,7 @@ defmodule Panoramix.Query do
     end
   end
 
-  defp build_query({field, value}, query_fields)
-       when field in [
-              :granularity,
-              :dimension,
-              :dimensions,
-              :metric,
-              :query_type,
-              :threshold,
-              :merge,
-              :analysis_types,
-              :limit_spec,
-              :limit,
-              :search_dimensions,
-              :query,
-              :sort
-            ] do
-    # For these fields, we just include the value verbatim.
+  defp build_query({field, value}, query_fields) when field in @unmapped_query_fields do
     [{field, value}] ++ query_fields
   end
 
@@ -801,28 +805,29 @@ defmodule Panoramix.Query do
     end
 
     [
-      queryType: query.query_type,
-      dataSource: query.data_source,
-      intervals: query.intervals,
-      granularity: query.granularity,
       aggregations: query.aggregations,
-      postAggregations: query.post_aggregations,
-      filter: query.filter,
+      analysisTypes: query.analysis_types,
+      bound: query.bound,
+      context: query.context,
+      dataSource: query.data_source,
       dimension: query.dimension,
       dimensions: query.dimensions,
-      metric: query.metric,
-      threshold: query.threshold,
-      context: query.context,
-      toInclude: query.to_include,
-      merge: query.merge,
-      analysisTypes: query.analysis_types,
-      limitSpec: query.limit_spec,
-      bound: query.bound,
-      virtualColumns: query.virtual_columns,
+      filter: query.filter,
+      granularity: query.granularity,
+      intervals: query.intervals,
       limit: query.limit,
-      searchDimensions: query.search_dimensions,
+      limitSpec: query.limit_spec,
+      merge: query.merge,
+      metric: query.metric,
+      postAggregations: query.post_aggregations,
       query: query.query,
-      sort: query.sort
+      queryType: query.query_type,
+      searchDimensions: query.search_dimensions,
+      sort: query.sort,
+      subtotalsSpec: query.subtotals_spec,
+      threshold: query.threshold,
+      toInclude: query.to_include,
+      virtualColumns: query.virtual_columns
     ]
     |> Enum.reject(fn {_, v} -> is_nil(v) end)
     |> Enum.into(%{})

--- a/lib/panoramix/query.ex
+++ b/lib/panoramix/query.ex
@@ -279,6 +279,10 @@ defmodule Panoramix.Query do
     end
   end
 
+  defp build_aggregations({:^, _, [aggregations]}) do
+    aggregations
+  end
+
   defp build_aggregations(aggregations) do
     Enum.map(aggregations, &build_aggregation/1)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Panoramix.MixProject do
       source_url: "https://github.com/GameAnalytics/panoramix",
       homepage_url: "https://github.com/GameAnalytics/panoramix",
       docs: [
-        main: "Panoramix", # The main page in the docs
+        # The main page in the docs
+        main: "Panoramix",
         extras: ["README.md"]
       ]
     ]
@@ -47,7 +48,7 @@ defmodule Panoramix.MixProject do
       {:timex, "~> 3.1"},
       {:dialyxir, "~> 1.0-rc.3", only: [:dev], runtime: false},
       {:credo, "~> 1.7.0", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.29.1", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.29.1", only: :dev, runtime: false}
     ]
   end
 end

--- a/test/panoramix_test.exs
+++ b/test/panoramix_test.exs
@@ -4,802 +4,1063 @@ defmodule PanoramixTest do
   use Panoramix
 
   test "builds a query" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day
+      )
+
     assert is_binary(Panoramix.Query.to_json(query))
-    #IO.puts Panoramix.Query.to_json(query)
+    # IO.puts Panoramix.Query.to_json(query)
   end
 
   test "builds a query with an aggregation" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                    unique_ids: hyperUnique(:user_unique)]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [event_count: count(), unique_ids: hyperUnique(:user_unique)]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["aggregations"] == [%{"name" => "event_count",
-                                         "type" => "count"},
-                                       %{"name" => "unique_ids",
-                                         "type" => "hyperUnique",
-                                         "fieldName" => "user_unique"}]
-    #IO.puts json
+    decoded = Jason.decode!(json)
+
+    assert decoded["aggregations"] == [
+             %{"name" => "event_count", "type" => "count"},
+             %{"name" => "unique_ids", "type" => "hyperUnique", "fieldName" => "user_unique"}
+           ]
+
+    # IO.puts json
   end
 
   test "builds a query with an aggregation that has an extra parameter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                    unique_ids: hyperUnique(:user_unique, round: true)]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [event_count: count(), unique_ids: hyperUnique(:user_unique, round: true)]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["aggregations"] == [%{"name" => "event_count",
-                                         "type" => "count"},
-                                       %{"name" => "unique_ids",
-                                         "type" => "hyperUnique",
-                                         "fieldName" => "user_unique",
-                                         "round" => true}]
-    #IO.puts json
+    decoded = Jason.decode!(json)
+
+    assert decoded["aggregations"] == [
+             %{"name" => "event_count", "type" => "count"},
+             %{
+               "name" => "unique_ids",
+               "type" => "hyperUnique",
+               "fieldName" => "user_unique",
+               "round" => true
+             }
+           ]
+
+    # IO.puts json
   end
 
   test "builds a query with an aggregation type that needs a name normalization" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                    unique_ids: hllSketchMerge(:user_unique, round: true)]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [
+          event_count: count(),
+          unique_ids: hllSketchMerge(:user_unique, round: true)
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["aggregations"] == [%{"name" => "event_count",
-                                         "type" => "count"},
-                                       %{"name" => "unique_ids",
-                                         "type" => "HLLSketchMerge",
-                                         "fieldName" => "user_unique",
-                                         "round" => true}]
-    #IO.puts json
+    decoded = Jason.decode!(json)
+
+    assert decoded["aggregations"] == [
+             %{"name" => "event_count", "type" => "count"},
+             %{
+               "name" => "unique_ids",
+               "type" => "HLLSketchMerge",
+               "fieldName" => "user_unique",
+               "round" => true
+             }
+           ]
+
+    # IO.puts json
   end
 
   test "builds a query with a filtered aggregation" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [
-        event_count: count(),
-        interesting_event_count: count() when dimensions.interesting == "true"
-      ]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [
+          event_count: count(),
+          interesting_event_count: count() when dimensions.interesting == "true"
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
+    decoded = Jason.decode!(json)
+
     assert decoded["aggregations"] == [
-      %{"name" => "event_count",
-        "type" => "count"},
-      %{"type" => "filtered",
-        "filter" => %{"type" => "selector",
-                      "dimension" => "interesting",
-                      "value" => "true"},
-        # NB: it seems to be correct to put the name on the inner aggregator!
-        "aggregator" =>
-          %{"name" => "interesting_event_count",
-            "type" => "count"}}
-    ]
-    #IO.puts json
+             %{"name" => "event_count", "type" => "count"},
+             %{
+               "type" => "filtered",
+               "filter" => %{
+                 "type" => "selector",
+                 "dimension" => "interesting",
+                 "value" => "true"
+               },
+               # NB: it seems to be correct to put the name on the inner aggregator!
+               "aggregator" => %{"name" => "interesting_event_count", "type" => "count"}
+             }
+           ]
+
+    # IO.puts json
   end
 
   test "builds a query with a filtered aggregation, but the filter is nil" do
     my_filter = nil
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [
-        interesting_event_count: count() when ^my_filter
-      ]
+
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [
+          interesting_event_count: count() when ^my_filter
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
+    decoded = Jason.decode!(json)
     # In this case, there is no need to add a filter to the aggregator
     assert decoded["aggregations"] == [
-      %{"name" => "interesting_event_count",
-        "type" => "count"}
-    ]
+             %{"name" => "interesting_event_count", "type" => "count"}
+           ]
+
     # IO.puts json
   end
 
   test "set an aggregation after building the query" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day
-    query = query |>
-      from(aggregations: [event_count: count()])
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day
+      )
+
+    query =
+      query
+      |> from(aggregations: [event_count: count()])
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["aggregations"] == [%{"name" => "event_count",
-                                         "type" => "count"}]
-    #IO.puts json
+    decoded = Jason.decode!(json)
+    assert decoded["aggregations"] == [%{"name" => "event_count", "type" => "count"}]
+    # IO.puts json
   end
 
   test "build query with column comparison filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == dimensions["bar"]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == dimensions["bar"]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "columnComparison",
-                                  "dimensions" => ["foo", "bar"]}
+    decoded = Jason.decode!(json)
+    assert decoded["filter"] == %{"type" => "columnComparison", "dimensions" => ["foo", "bar"]}
   end
 
   test "build query with selector filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar"
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "selector",
-                                  "dimension" => "foo",
-                                  "value" => "bar"}
+    decoded = Jason.decode!(json)
+    assert decoded["filter"] == %{"type" => "selector", "dimension" => "foo", "value" => "bar"}
   end
 
   test "build query with two filters ANDed together" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar" and dimensions.bar == dimensions.foo
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar" and dimensions.bar == dimensions.foo
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "and",
-                                  "fields" =>
-                                    [%{"type" => "selector",
-                                       "dimension" => "foo",
-                                       "value" => "bar"},
-                                     %{"type" => "columnComparison",
-                                       "dimensions" => ["bar", "foo"]}]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "and",
+             "fields" => [
+               %{"type" => "selector", "dimension" => "foo", "value" => "bar"},
+               %{"type" => "columnComparison", "dimensions" => ["bar", "foo"]}
+             ]
+           }
   end
 
   test "build query with three filters ANDed together" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar" and dimensions.bar == dimensions.foo and 0 < dimensions.baz < 10
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter:
+          dimensions.foo == "bar" and dimensions.bar == dimensions.foo and 0 < dimensions.baz < 10
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "and",
-                                  "fields" =>
-                                    [%{"type" => "selector",
-                                       "dimension" => "foo",
-                                       "value" => "bar"},
-                                     %{"type" => "columnComparison",
-                                       "dimensions" => ["bar", "foo"]},
-                                     %{"type" => "bound",
-                                       "dimension" => "baz",
-                                       "ordering" => "numeric",
-                                       "lower" => "0", "lowerStrict" => true,
-                                       "upper" => "10", "upperStrict" => true}]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "and",
+             "fields" => [
+               %{"type" => "selector", "dimension" => "foo", "value" => "bar"},
+               %{"type" => "columnComparison", "dimensions" => ["bar", "foo"]},
+               %{
+                 "type" => "bound",
+                 "dimension" => "baz",
+                 "ordering" => "numeric",
+                 "lower" => "0",
+                 "lowerStrict" => true,
+                 "upper" => "10",
+                 "upperStrict" => true
+               }
+             ]
+           }
   end
 
   test "build query with two filters ORed together" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar" or dimensions.bar == dimensions.foo
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar" or dimensions.bar == dimensions.foo
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "or",
-                                  "fields" =>
-                                    [%{"type" => "selector",
-                                       "dimension" => "foo",
-                                       "value" => "bar"},
-                                     %{"type" => "columnComparison",
-                                       "dimensions" => ["bar", "foo"]}]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "or",
+             "fields" => [
+               %{"type" => "selector", "dimension" => "foo", "value" => "bar"},
+               %{"type" => "columnComparison", "dimensions" => ["bar", "foo"]}
+             ]
+           }
   end
 
   test "build query with AND and OR filters" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      # 'and' has higher precedence, so this should get parsed as
-      # (foo == "bar" or (bar == foo and baz == 17))
-      filter: dimensions.foo == "bar" or dimensions.bar == dimensions.foo and dimensions.baz == 17
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        # 'and' has higher precedence, so this should get parsed as
+        # (foo == "bar" or (bar == foo and baz == 17))
+        filter:
+          dimensions.foo == "bar" or (dimensions.bar == dimensions.foo and dimensions.baz == 17)
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "or",
-                                  "fields" =>
-                                    [%{"type" => "selector",
-                                       "dimension" => "foo",
-                                       "value" => "bar"},
-                                     %{"type" => "and",
-                                       "fields" => [
-                                         %{"type" => "columnComparison",
-                                           "dimensions" => ["bar", "foo"]},
-                                         %{"type" => "selector",
-                                           "dimension" => "baz",
-                                           "value" => 17}]}]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "or",
+             "fields" => [
+               %{"type" => "selector", "dimension" => "foo", "value" => "bar"},
+               %{
+                 "type" => "and",
+                 "fields" => [
+                   %{"type" => "columnComparison", "dimensions" => ["bar", "foo"]},
+                   %{"type" => "selector", "dimension" => "baz", "value" => 17}
+                 ]
+               }
+             ]
+           }
   end
 
   test "build query with a not equal to filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo != "bar"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo != "bar"
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "not",
-                                  "field" =>
-                                    %{"type" => "selector",
-                                      "dimension" => "foo",
-                                      "value" => "bar"}}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "not",
+             "field" => %{"type" => "selector", "dimension" => "foo", "value" => "bar"}
+           }
   end
 
   test "build query with a not equal to filter based on columnComparison" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo != dimensions.bar
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo != dimensions.bar
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "not",
-                                  "field" =>
-                                    %{"type" => "columnComparison",
-                                      "dimensions" => ["foo", "bar"]}}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "not",
+             "field" => %{"type" => "columnComparison", "dimensions" => ["foo", "bar"]}
+           }
   end
 
   test "equal filter can't have value on the left hand side" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+      )
 
-    assert_raise RuntimeError, "left operand of == must be a dimension", fn() ->
-      ast = quote do
-        use Panoramix
-        from unquote(query),
-          filter: "bar" == dimensions.foo
-      end
+    assert_raise RuntimeError, "left operand of == must be a dimension", fn ->
+      ast =
+        quote do
+          use Panoramix
+
+          from(unquote(query),
+            filter: "bar" == dimensions.foo
+          )
+        end
+
       Code.eval_quoted(ast)
     end
 
-    assert_raise RuntimeError, "left operand of != must be a dimension", fn() ->
-      ast = quote do
-        use Panoramix
-        from unquote(query),
-          filter: "bar" != dimensions.foo
-      end
+    assert_raise RuntimeError, "left operand of != must be a dimension", fn ->
+      ast =
+        quote do
+          use Panoramix
+
+          from(unquote(query),
+            filter: "bar" != dimensions.foo
+          )
+        end
+
       Code.eval_quoted(ast)
     end
   end
 
   test "build query with a NOT filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: not (dimensions.foo == "bar")
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: not (dimensions.foo == "bar")
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "not",
-                                  "field" =>
-                                    %{"type" => "selector",
-                                      "dimension" => "foo",
-                                      "value" => "bar"}}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "not",
+             "field" => %{"type" => "selector", "dimension" => "foo", "value" => "bar"}
+           }
   end
 
   test "build query with an 'in' filter" do
     x = "baz"
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo in ["bar", x]
+
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo in ["bar", x]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "in",
-                                  "dimension" => "foo",
-                                  "values" => ["bar", "baz"]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "in",
+             "dimension" => "foo",
+             "values" => ["bar", "baz"]
+           }
   end
 
   test "build query with a non-strict 'bound' filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: 1 <= dimensions.foo <= 10
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: 1 <= dimensions.foo <= 10
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "bound",
-                                  "dimension" => "foo",
-                                  "lower" => "1",
-                                  "upper" => "10",
-                                  "lowerStrict" => false,
-                                  "upperStrict" => false,
-                                  "ordering" => "numeric"}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "bound",
+             "dimension" => "foo",
+             "lower" => "1",
+             "upper" => "10",
+             "lowerStrict" => false,
+             "upperStrict" => false,
+             "ordering" => "numeric"
+           }
   end
 
   test "build query with a lower-strict 'bound' filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: "aaa" < dimensions.foo <= "bbb"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: "aaa" < dimensions.foo <= "bbb"
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "bound",
-                                  "dimension" => "foo",
-                                  "lower" => "aaa",
-                                  "upper" => "bbb",
-                                  "lowerStrict" => true,
-                                  "upperStrict" => false,
-                                  "ordering" => "lexicographic"}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "bound",
+             "dimension" => "foo",
+             "lower" => "aaa",
+             "upper" => "bbb",
+             "lowerStrict" => true,
+             "upperStrict" => false,
+             "ordering" => "lexicographic"
+           }
   end
 
   test "build query with an 'expression' filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: expression("foo / 1000 < bar")
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: expression("foo / 1000 < bar")
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "expression",
-                                  "expression" => "foo / 1000 < bar"}
+    decoded = Jason.decode!(json)
+    assert decoded["filter"] == %{"type" => "expression", "expression" => "foo / 1000 < bar"}
   end
 
   test "add extra filter to existing query" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar"
-    query = from query,
-      filter: dimensions.bar == "baz" and ^query.filter
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar"
+      )
+
+    query =
+      from(query,
+        filter: dimensions.bar == "baz" and ^query.filter
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "and",
-                                  "fields" =>
-                                    [%{"type" => "selector",
-                                       "dimension" => "bar",
-                                       "value" => "baz"},
-                                     %{"type" => "selector",
-                                       "dimension" => "foo",
-                                       "value" => "bar"}]}
+    decoded = Jason.decode!(json)
+
+    assert decoded["filter"] == %{
+             "type" => "and",
+             "fields" => [
+               %{"type" => "selector", "dimension" => "bar", "value" => "baz"},
+               %{"type" => "selector", "dimension" => "foo", "value" => "bar"}
+             ]
+           }
   end
 
   test "add extra filter to a 'nil' filter with 'and'" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+      )
+
     # Adding a new filter here, when there is no existing filter,
     # means that the new filter just gets used as the query filter.
-    query = from query,
-      filter: dimensions.bar == "baz" and ^query.filter
+    query =
+      from(query,
+        filter: dimensions.bar == "baz" and ^query.filter
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert decoded["filter"] == %{"type" => "selector",
-                                  "dimension" => "bar",
-                                  "value" => "baz"}
+    decoded = Jason.decode!(json)
+    assert decoded["filter"] == %{"type" => "selector", "dimension" => "bar", "value" => "baz"}
   end
 
   test "cannot add filter to 'nil' filter with 'or'" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+      )
+
     # It's not meaningful to use the empty filter in an "or" expression
     assert_raise RuntimeError, "right operand to 'or' must not be nil", fn ->
-      from query,
+      from(query,
         filter: dimensions.bar == "baz" or ^query.filter
+      )
     end
+
     assert_raise RuntimeError, "left operand to 'or' must not be nil", fn ->
-      from query,
+      from(query,
         filter: ^query.filter or dimensions.bar == "baz"
+      )
     end
   end
 
   test "cannot apply 'not' to 'nil' filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"]
+      )
+
     # It's not meaningful to use the empty filter in an "or" expression
     assert_raise RuntimeError, "operand to 'not' must not be nil", fn ->
-      from query,
-        filter: not ^query.filter
+      from(query,
+        filter: not (^query.filter)
+      )
     end
   end
 
   test "extract filter from JSON object" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar"
+      )
+
     json = Panoramix.Query.to_json(query)
-    %{"filter" => filter} = Jason.decode! json
-    new_query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: ^filter
-    assert %{"filter" => %{"type" => "selector",
-                           "dimension" => "foo",
-                           "value" => "bar"}} = Jason.decode! Panoramix.Query.to_json new_query
+    %{"filter" => filter} = Jason.decode!(json)
+
+    new_query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: ^filter
+      )
+
+    assert %{"filter" => %{"type" => "selector", "dimension" => "foo", "value" => "bar"}} =
+             Jason.decode!(Panoramix.Query.to_json(new_query))
   end
 
   test "build a topN query" do
-    query = from "my_datasource",
-      query_type: "topN",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      dimension: "foo",
-      metric: "size",
-      threshold: 10
+    query =
+      from("my_datasource",
+        query_type: "topN",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        dimension: "foo",
+        metric: "size",
+        threshold: 10
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "topN",
-             "dimension" => "foo",
-             "metric" => "size",
-             "threshold" => 10} = decoded
+    decoded = Jason.decode!(json)
+
+    assert %{"queryType" => "topN", "dimension" => "foo", "metric" => "size", "threshold" => 10} =
+             decoded
   end
 
   test "build a query with a query context" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      filter: dimensions.foo == "bar",
-      context: %{timeout: 0,
-                 priority: 100,
-                 queryId: "my-unique-query-id",
-                 skipEmptyBuckets: true}
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        filter: dimensions.foo == "bar",
+        context: %{
+          timeout: 0,
+          priority: 100,
+          queryId: "my-unique-query-id",
+          skipEmptyBuckets: true
+        }
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"timeout" => 0,
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "timeout" => 0,
              "priority" => 100,
              "queryId" => "my-unique-query-id",
-             "skipEmptyBuckets" => true} == decoded["context"]
+             "skipEmptyBuckets" => true
+           } == decoded["context"]
   end
 
   test "build a query with a query context while supplying default values from app config" do
-    query = from "my_datasource",
-                 query_type: "timeseries",
-                 intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-                 granularity: :day,
-                 context: %{queryId: "my-unique-query-id",
-                            skipEmptyBuckets: true}
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        context: %{queryId: "my-unique-query-id", skipEmptyBuckets: true}
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"timeout" => 120_000,
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "timeout" => 120_000,
              "priority" => 0,
              "queryId" => "my-unique-query-id",
-             "skipEmptyBuckets" => true} == decoded["context"]
+             "skipEmptyBuckets" => true
+           } == decoded["context"]
   end
 
   test "add query context to an existing query and maintain defaults from app config" do
-    query = from "my_datasource",
-                 query_type: "timeseries",
-                 intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-                 granularity: :day,
-                 context: %{queryId: "my-unique-query-id",
-                            skipEmptyBuckets: true}
-    query = from query,
-                 context: %{queryId: "another-unique-query-id",
-                            skipEmptyBuckets: false}
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        context: %{queryId: "my-unique-query-id", skipEmptyBuckets: true}
+      )
+
+    query =
+      from(query,
+        context: %{queryId: "another-unique-query-id", skipEmptyBuckets: false}
+      )
+
     json = Panoramix.Query.to_json(query)
-    decoded = Jason.decode! json
-    assert %{"timeout" => 120_000,
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "timeout" => 120_000,
              "priority" => 0,
              "queryId" => "another-unique-query-id",
-             "skipEmptyBuckets" => false} == decoded["context"]
+             "skipEmptyBuckets" => false
+           } == decoded["context"]
   end
 
   test "build a query with an arithmetic post-aggregation" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                     unique_ids: hyperUnique(:user_unique)],
-      post_aggregations: [
-        mean_events_per_user: aggregations.event_count / aggregations["unique_ids"]
-      ]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [event_count: count(), unique_ids: hyperUnique(:user_unique)],
+        post_aggregations: [
+          mean_events_per_user: aggregations.event_count / aggregations["unique_ids"]
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert [%{"type" => "arithmetic",
-              "name" => "mean_events_per_user",
-              "fn" => "/",
-              "fields" => [
-                %{"type" => "fieldAccess",
-                  "fieldName" => "event_count"},
-                %{"type" => "fieldAccess",
-                  "fieldName" => "unique_ids"}
-              ]}] == decoded["postAggregations"]
+    decoded = Jason.decode!(json)
+
+    assert [
+             %{
+               "type" => "arithmetic",
+               "name" => "mean_events_per_user",
+               "fn" => "/",
+               "fields" => [
+                 %{"type" => "fieldAccess", "fieldName" => "event_count"},
+                 %{"type" => "fieldAccess", "fieldName" => "unique_ids"}
+               ]
+             }
+           ] == decoded["postAggregations"]
   end
 
   test "build a query with an arithmetic post-aggregation including constant" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                     unique_ids: hyperUnique(:user_unique)],
-      post_aggregations: [
-        mean_events_per_user_pct: aggregations.event_count / aggregations["unique_ids"] * 100
-      ]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [event_count: count(), unique_ids: hyperUnique(:user_unique)],
+        post_aggregations: [
+          mean_events_per_user_pct: aggregations.event_count / aggregations["unique_ids"] * 100
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert [%{"type" => "arithmetic",
-              "name" => "mean_events_per_user_pct",
-              "fn" => "*",
-              "fields" => [
-                %{"type" => "arithmetic",
-                  "fn" => "/",
-                  "fields" => [
-                    %{"type" => "fieldAccess",
-                      "fieldName" => "event_count"},
-                    %{"type" => "fieldAccess",
-                      "fieldName" => "unique_ids"}
-                  ]},
-                %{"type" => "constant",
-                  "value" => 100}]}] == decoded["postAggregations"]
+    decoded = Jason.decode!(json)
+
+    assert [
+             %{
+               "type" => "arithmetic",
+               "name" => "mean_events_per_user_pct",
+               "fn" => "*",
+               "fields" => [
+                 %{
+                   "type" => "arithmetic",
+                   "fn" => "/",
+                   "fields" => [
+                     %{"type" => "fieldAccess", "fieldName" => "event_count"},
+                     %{"type" => "fieldAccess", "fieldName" => "unique_ids"}
+                   ]
+                 },
+                 %{"type" => "constant", "value" => 100}
+               ]
+             }
+           ] == decoded["postAggregations"]
   end
 
   test "build a query with post-aggregation functions" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      aggregations: [event_count: count(),
-                     unique_ids: hyperUnique(:user_unique)],
-      post_aggregations: [
-        cardinality: hyperUniqueCardinality(:unique_ids),
-        greatest: doubleGreatest([aggregations.event_count, aggregations.unique_ids]),
-        histogram: buckets(:histogram_data, bucketSize: 42, offset: 17)
-      ]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        aggregations: [event_count: count(), unique_ids: hyperUnique(:user_unique)],
+        post_aggregations: [
+          cardinality: hyperUniqueCardinality(:unique_ids),
+          greatest: doubleGreatest([aggregations.event_count, aggregations.unique_ids]),
+          histogram: buckets(:histogram_data, bucketSize: 42, offset: 17)
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert [%{"type" => "hyperUniqueCardinality",
-              "name" => "cardinality",
-              "fieldName" => "unique_ids"},
-            %{"type" => "doubleGreatest",
-              "name" => "greatest",
-              "fields" => [
-                %{"fieldName" => "event_count", "type" => "fieldAccess"},
-                %{"fieldName" => "unique_ids", "type" => "fieldAccess"}
-              ]},
-            %{"name" => "histogram",
-              "type" => "buckets",
-              "fieldName" => "histogram_data",
-              "bucketSize" => 42,
-              "offset" => 17}
+    decoded = Jason.decode!(json)
+
+    assert [
+             %{
+               "type" => "hyperUniqueCardinality",
+               "name" => "cardinality",
+               "fieldName" => "unique_ids"
+             },
+             %{
+               "type" => "doubleGreatest",
+               "name" => "greatest",
+               "fields" => [
+                 %{"fieldName" => "event_count", "type" => "fieldAccess"},
+                 %{"fieldName" => "unique_ids", "type" => "fieldAccess"}
+               ]
+             },
+             %{
+               "name" => "histogram",
+               "type" => "buckets",
+               "fieldName" => "histogram_data",
+               "bucketSize" => 42,
+               "offset" => 17
+             }
            ] == decoded["postAggregations"]
   end
 
   test "build a segmentMetadata query" do
-    query = from "my_datasource",
-      query_type: "segmentMetadata",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      to_include: :all,
-      merge: true,
-      analysis_types: [:cardinality, :minmax]
+    query =
+      from("my_datasource",
+        query_type: "segmentMetadata",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        to_include: :all,
+        merge: true,
+        analysis_types: [:cardinality, :minmax]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "segmentMetadata",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "segmentMetadata",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
              "dataSource" => "my_datasource",
              "toInclude" => %{"type" => "all"},
              "merge" => true,
              "analysisTypes" => ["cardinality", "minmax"],
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a segmentMetadata query limited to certain columns" do
-    query = from "my_datasource",
-      query_type: "segmentMetadata",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      to_include: ["foo", "bar"],
-      merge: true,
-      analysis_types: [:cardinality, :minmax]
+    query =
+      from("my_datasource",
+        query_type: "segmentMetadata",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        to_include: ["foo", "bar"],
+        merge: true,
+        analysis_types: [:cardinality, :minmax]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "segmentMetadata",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "segmentMetadata",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
              "dataSource" => "my_datasource",
              "toInclude" => %{"type" => "list", "columns" => ["foo", "bar"]},
              "merge" => true,
              "analysisTypes" => ["cardinality", "minmax"],
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a query using date structs" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: [{~D[2018-05-29], ~D[2018-06-05]}],
-      granularity: :day
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: [{~D[2018-05-29], ~D[2018-06-05]}],
+        granularity: :day
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "timeseries",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29/2018-06-05"],
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a query using datetime structs" do
-    from = Timex.to_datetime {{2018, 5, 29}, {1, 30, 0}}
-    to = Timex.to_datetime {{2018, 6, 5}, {18, 0, 0}}
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: [{from, to}],
-      granularity: :day
+    from = Timex.to_datetime({{2018, 5, 29}, {1, 30, 0}})
+    to = Timex.to_datetime({{2018, 6, 5}, {18, 0, 0}})
+
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: [{from, to}],
+        granularity: :day
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "timeseries",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "intervals" => ["2018-05-29T01:30:00+00:00/2018-06-05T18:00:00+00:00"],
              "granularity" => "day",
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a timeBoundary query with a 'maxTime' bound" do
-    query = from "my_datasource",
-      query_type: "timeBoundary",
-      bound: :maxTime
+    query =
+      from("my_datasource",
+        query_type: "timeBoundary",
+        bound: :maxTime
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "timeBoundary",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "timeBoundary",
              "dataSource" => "my_datasource",
              "bound" => "maxTime",
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a query with a virtual column" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-      granularity: :day,
-      virtual_columns: [plus_one: expression("foo + 1", :long)],
-      aggregations: [plus_one_sum: longSum(:plus_one)]
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+        granularity: :day,
+        virtual_columns: [plus_one: expression("foo + 1", :long)],
+        aggregations: [plus_one_sum: longSum(:plus_one)]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "timeseries",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-             "virtualColumns" => [%{"name" => "plus_one",
-                                    "type" => "expression",
-                                    "expression" => "foo + 1",
-                                    "outputType" => "LONG"}],
-             "aggregations" => [%{"name" => "plus_one_sum",
-                                  "type" => "longSum",
-                                  "fieldName" => "plus_one"}],
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "virtualColumns" => [
+               %{
+                 "name" => "plus_one",
+                 "type" => "expression",
+                 "expression" => "foo + 1",
+                 "outputType" => "LONG"
+               }
+             ],
+             "aggregations" => [
+               %{"name" => "plus_one_sum", "type" => "longSum", "fieldName" => "plus_one"}
+             ],
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a query with an interval filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-      granularity: :day,
-      # Let's use all three kinds of intervals we support: strings, dates and datetimes
-      filter: dimensions.__time in intervals([
-        "2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00",
-        {~D[2018-06-05], ~D[2018-06-12]},
-        {Timex.to_datetime({{2018, 6, 12}, {1, 30, 0}}), Timex.to_datetime({{2018, 6, 19}, {18, 0, 0}})}])
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
+        granularity: :day,
+        # Let's use all three kinds of intervals we support: strings, dates and datetimes
+        filter:
+          dimensions.__time in intervals([
+            "2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00",
+            {~D[2018-06-05], ~D[2018-06-12]},
+            {Timex.to_datetime({{2018, 6, 12}, {1, 30, 0}}),
+             Timex.to_datetime({{2018, 6, 19}, {18, 0, 0}})}
+          ])
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
-    decoded = Jason.decode! json
-    assert %{"queryType" => "timeseries",
+    decoded = Jason.decode!(json)
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-             "filter" => %{"type" => "interval",
-                           "dimension" => "__time",
-                           "intervals" => [
-                             "2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00",
-                             "2018-06-05/2018-06-12",
-                             "2018-06-12T01:30:00+00:00/2018-06-19T18:00:00+00:00"]},
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "filter" => %{
+               "type" => "interval",
+               "dimension" => "__time",
+               "intervals" => [
+                 "2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00",
+                 "2018-06-05/2018-06-12",
+                 "2018-06-12T01:30:00+00:00/2018-06-19T18:00:00+00:00"
+               ]
+             },
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "build a query filtering on a lookup" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-      granularity: :day,
-      filter: dimensions.foo |> lookup(:foo_to_bar) == "expected_bar"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
+        granularity: :day,
+        filter: dimensions.foo |> lookup(:foo_to_bar) == "expected_bar"
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
     decoded = Jason.decode!(json)
-    assert %{"queryType" => "timeseries",
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-             "filter" => %{"type" => "selector",
-                           "dimension" => "foo",
-                           "value" => "expected_bar",
-                           "extractionFn" => %{"type" => "registeredLookup",
-                                               "lookup" => "foo_to_bar"}},
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "filter" => %{
+               "type" => "selector",
+               "dimension" => "foo",
+               "value" => "expected_bar",
+               "extractionFn" => %{"type" => "registeredLookup", "lookup" => "foo_to_bar"}
+             },
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "use lookup in column comparison filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-      granularity: :day,
-      filter: dimensions["foo"] |> lookup(:foo_to_bar, replaceMissingValueWith: "missing") == dimensions.baz
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
+        granularity: :day,
+        filter:
+          dimensions["foo"] |> lookup(:foo_to_bar, replaceMissingValueWith: "missing") ==
+            dimensions.baz
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
     decoded = Jason.decode!(json)
-    assert %{"queryType" => "timeseries",
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-             "filter" => %{"type" => "columnComparison",
-                           "dimensions" => [
-                             %{"dimension" => "foo",
-                               "extractionFn" => %{"lookup" => "foo_to_bar",
-                                                   "type" => "registeredLookup",
-                                                   "replaceMissingValueWith" => "missing"},
-                               "type" => "extraction"},
-                             "baz"]},
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "filter" => %{
+               "type" => "columnComparison",
+               "dimensions" => [
+                 %{
+                   "dimension" => "foo",
+                   "extractionFn" => %{
+                     "lookup" => "foo_to_bar",
+                     "type" => "registeredLookup",
+                     "replaceMissingValueWith" => "missing"
+                   },
+                   "type" => "extraction"
+                 },
+                 "baz"
+               ]
+             },
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "chain two lookups in filter" do
-    query = from "my_datasource",
-      query_type: "timeseries",
-      intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-      granularity: :day,
-      filter: dimensions.foo
-      |> lookup(:foo_to_bar)
-      |> lookup(:bar_to_baz, retainMissingValue: true, injective: true) == "expected_baz"
+    query =
+      from("my_datasource",
+        query_type: "timeseries",
+        intervals: ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
+        granularity: :day,
+        filter:
+          dimensions.foo
+          |> lookup(:foo_to_bar)
+          |> lookup(:bar_to_baz, retainMissingValue: true, injective: true) == "expected_baz"
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
     decoded = Jason.decode!(json)
-    assert %{"queryType" => "timeseries",
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => "my_datasource",
              "granularity" => "day",
              "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-20T00:00:00+00:00"],
-             "filter" => %{"type" => "selector",
-                           "dimension" => "foo",
-                           "value" => "expected_baz",
-                           "extractionFn" => %{
-                             "type" => "cascade",
-                             "extractionFns" => [
-                               %{"type" => "registeredLookup",
-                                 "lookup" => "foo_to_bar"},
-                               %{"type" => "registeredLookup",
-                                 "lookup" => "bar_to_baz",
-                                 "retainMissingValue" => true,
-                                 "injective" => true}]}},
-             "context" => %{"timeout" => 120_000, "priority" => 0}} == decoded
+             "filter" => %{
+               "type" => "selector",
+               "dimension" => "foo",
+               "value" => "expected_baz",
+               "extractionFn" => %{
+                 "type" => "cascade",
+                 "extractionFns" => [
+                   %{"type" => "registeredLookup", "lookup" => "foo_to_bar"},
+                   %{
+                     "type" => "registeredLookup",
+                     "lookup" => "bar_to_baz",
+                     "retainMissingValue" => true,
+                     "injective" => true
+                   }
+                 ]
+               }
+             },
+             "context" => %{"timeout" => 120_000, "priority" => 0}
+           } == decoded
   end
 
   test "builds a query with hllSketchEstimate post-aggregation" do
@@ -824,44 +1085,44 @@ defmodule PanoramixTest do
     assert is_binary(json)
 
     assert Jason.decode!(json) ==
-        %{
-          "aggregations" => [
-            %{
-              "fieldName" => "hyper_unique",
-              "name" => "hyper_unique_agg",
-              "round" => true,
-              "type" => "hyperUnique"
-            },
-            %{
-              "fieldName" => "hll_sketch",
-              "name" => "hll_sketch_agg",
-              "round" => true,
-              "type" => "HLLSketchMerge"
-            }
-          ],
-          "context" => %{"priority" => 0, "timeout" => 120_000},
-          "dataSource" => "my_datasource",
-          "dimension" => "foo",
-          "granularity" => "day",
-          "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
-          "metric" => %{"type" => "dimension"},
-          "postAggregations" => [
-            %{
-              "fields" => [
-                %{"fieldName" => "hyper_unique_agg", "type" => "fieldAccess"},
-                %{
-                  "field" => %{"fieldName" => "hll_sketch_agg", "type" => "fieldAccess"},
-                  "type" => "HLLSketchEstimate"
-                }
-              ],
-              "fn" => "/",
-              "name" => "post_agg",
-              "type" => "arithmetic"
-            }
-          ],
-          "queryType" => "topN",
-          "threshold" => 10
-        }
+             %{
+               "aggregations" => [
+                 %{
+                   "fieldName" => "hyper_unique",
+                   "name" => "hyper_unique_agg",
+                   "round" => true,
+                   "type" => "hyperUnique"
+                 },
+                 %{
+                   "fieldName" => "hll_sketch",
+                   "name" => "hll_sketch_agg",
+                   "round" => true,
+                   "type" => "HLLSketchMerge"
+                 }
+               ],
+               "context" => %{"priority" => 0, "timeout" => 120_000},
+               "dataSource" => "my_datasource",
+               "dimension" => "foo",
+               "granularity" => "day",
+               "intervals" => ["2018-05-29T00:00:00+00:00/2018-06-05T00:00:00+00:00"],
+               "metric" => %{"type" => "dimension"},
+               "postAggregations" => [
+                 %{
+                   "fields" => [
+                     %{"fieldName" => "hyper_unique_agg", "type" => "fieldAccess"},
+                     %{
+                       "field" => %{"fieldName" => "hll_sketch_agg", "type" => "fieldAccess"},
+                       "type" => "HLLSketchEstimate"
+                     }
+                   ],
+                   "fn" => "/",
+                   "name" => "post_agg",
+                   "type" => "arithmetic"
+                 }
+               ],
+               "queryType" => "topN",
+               "threshold" => 10
+             }
   end
 
   test "builds a query with hllSketchEstimate with options" do
@@ -878,7 +1139,9 @@ defmodule PanoramixTest do
           hll_sketch_agg: hllSketchMerge(:hll_sketch, round: true)
         ],
         post_aggregations: [
-          post_agg: aggregations.hyper_unique_agg / hllSketchEstimate(aggregations.hll_sketch_agg, round: true)
+          post_agg:
+            aggregations.hyper_unique_agg /
+              hllSketchEstimate(aggregations.hll_sketch_agg, round: true)
         ]
       )
 
@@ -886,20 +1149,20 @@ defmodule PanoramixTest do
     assert is_binary(json)
 
     assert Jason.decode!(json)["postAggregations"] == [
-      %{
-        "fields" => [
-          %{"fieldName" => "hyper_unique_agg", "type" => "fieldAccess"},
-          %{
-            "field" => %{"fieldName" => "hll_sketch_agg", "type" => "fieldAccess"},
-            "round" => true,
-            "type" => "HLLSketchEstimate"
-          }
-        ],
-        "fn" => "/",
-        "name" => "post_agg",
-        "type" => "arithmetic"
-      }
-    ]
+             %{
+               "fields" => [
+                 %{"fieldName" => "hyper_unique_agg", "type" => "fieldAccess"},
+                 %{
+                   "field" => %{"fieldName" => "hll_sketch_agg", "type" => "fieldAccess"},
+                   "round" => true,
+                   "type" => "HLLSketchEstimate"
+                 }
+               ],
+               "fn" => "/",
+               "name" => "post_agg",
+               "type" => "arithmetic"
+             }
+           ]
   end
 
   test "builds a query with hllSketchUnion" do
@@ -924,15 +1187,15 @@ defmodule PanoramixTest do
     assert is_binary(json)
 
     assert Jason.decode!(json)["postAggregations"] == [
-      %{
-        "fields" => [
-          %{"fieldName" => "sketch_a", "type" => "fieldAccess"},
-          %{"fieldName" => "sketch_b", "type" => "fieldAccess"}
-        ],
-        "name" => "post_agg",
-        "type" => "HLLSketchUnion"
-      }
-    ]
+             %{
+               "fields" => [
+                 %{"fieldName" => "sketch_a", "type" => "fieldAccess"},
+                 %{"fieldName" => "sketch_b", "type" => "fieldAccess"}
+               ],
+               "name" => "post_agg",
+               "type" => "HLLSketchUnion"
+             }
+           ]
   end
 
   test "builds a query with hllSketchUnion with options" do
@@ -949,12 +1212,14 @@ defmodule PanoramixTest do
           sketch_b: hllSketchMerge(:hll_sketch_b, round: true)
         ],
         post_aggregations: [
-          post_agg: hllSketchEstimate(
-            hllSketchUnion(
-              [aggregations.sketch_a, aggregations.sketch_b],
-              lgK: 2, tgtHllType: "HLL_4"
+          post_agg:
+            hllSketchEstimate(
+              hllSketchUnion(
+                [aggregations.sketch_a, aggregations.sketch_b],
+                lgK: 2,
+                tgtHllType: "HLL_4"
+              )
             )
-          )
         ]
       )
 
@@ -962,99 +1227,128 @@ defmodule PanoramixTest do
     assert is_binary(json)
 
     assert Jason.decode!(json)["postAggregations"] == [
-      %{
-        "field" => %{
-          "fields" => [
-            %{"fieldName" => "sketch_a", "type" => "fieldAccess"},
-            %{"fieldName" => "sketch_b", "type" => "fieldAccess"}
-          ],
-          "lgK" => 2,
-          "tgtHllType" => "HLL_4",
-          "type" => "HLLSketchUnion"
-        },
-        "name" => "post_agg",
-        "type" => "HLLSketchEstimate"
-      }
-    ]
+             %{
+               "field" => %{
+                 "fields" => [
+                   %{"fieldName" => "sketch_a", "type" => "fieldAccess"},
+                   %{"fieldName" => "sketch_b", "type" => "fieldAccess"}
+                 ],
+                 "lgK" => 2,
+                 "tgtHllType" => "HLL_4",
+                 "type" => "HLLSketchUnion"
+               },
+               "name" => "post_agg",
+               "type" => "HLLSketchEstimate"
+             }
+           ]
   end
 
   test "nested query" do
-    inner_query = from "my_datasource",
-      query_type: "topN",
-      intervals: ["2020-11-01/P7D"],
-      granularity: :day,
-      aggregations: [event_count: count()],
-      dimension: "foo",
-      metric: "event_count",
-      threshold: 10
-    query = from %{type: :query, query: inner_query},
-      query_type: "timeseries",
-      intervals: ["2020-11-01/P7D"],
-      granularity: :day,
-      aggregations: [foo_count: count(), event_count: longSum(:event_count)],
-      post_aggregations: [
-        mean_events_per_foo: aggregations.event_count / aggregations.foo_count
-      ]
+    inner_query =
+      from("my_datasource",
+        query_type: "topN",
+        intervals: ["2020-11-01/P7D"],
+        granularity: :day,
+        aggregations: [event_count: count()],
+        dimension: "foo",
+        metric: "event_count",
+        threshold: 10
+      )
+
+    query =
+      from(%{type: :query, query: inner_query},
+        query_type: "timeseries",
+        intervals: ["2020-11-01/P7D"],
+        granularity: :day,
+        aggregations: [foo_count: count(), event_count: longSum(:event_count)],
+        post_aggregations: [
+          mean_events_per_foo: aggregations.event_count / aggregations.foo_count
+        ]
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
     decoded = Jason.decode!(json)
-    assert %{"queryType" => "timeseries",
+
+    assert %{
+             "queryType" => "timeseries",
              "dataSource" => %{
                "type" => "query",
-               "query" => %{"aggregations" => [%{"name" => "event_count", "type" => "count"}],
-                            "context" => %{"priority" => 0, "timeout" => 120_000},
-                            "dataSource" => "my_datasource",
-                            "dimension" => "foo",
-                            "granularity" => "day",
-                            "intervals" => ["2020-11-01/P7D"],
-                            "metric" => "event_count",
-                            "queryType" => "topN",
-                            "threshold" => 10}},
+               "query" => %{
+                 "aggregations" => [%{"name" => "event_count", "type" => "count"}],
+                 "context" => %{"priority" => 0, "timeout" => 120_000},
+                 "dataSource" => "my_datasource",
+                 "dimension" => "foo",
+                 "granularity" => "day",
+                 "intervals" => ["2020-11-01/P7D"],
+                 "metric" => "event_count",
+                 "queryType" => "topN",
+                 "threshold" => 10
+               }
+             },
              "context" => %{"priority" => 0, "timeout" => 120_000},
              "granularity" => "day",
              "intervals" => ["2020-11-01/P7D"],
-             "aggregations" => [%{"name" => "foo_count", "type" => "count"},
-                                %{"fieldName" => "event_count", "name" => "event_count", "type" => "longSum"}],
-             "postAggregations" => [%{"name" => "mean_events_per_foo",
-                                      "fn" => "/",
-                                      "type" => "arithmetic",
-                                      "fields" => [%{"fieldName" => "event_count", "type" => "fieldAccess"},
-                                                   %{"fieldName" => "foo_count", "type" => "fieldAccess"}]}]} ==
-      decoded
+             "aggregations" => [
+               %{"name" => "foo_count", "type" => "count"},
+               %{"fieldName" => "event_count", "name" => "event_count", "type" => "longSum"}
+             ],
+             "postAggregations" => [
+               %{
+                 "name" => "mean_events_per_foo",
+                 "fn" => "/",
+                 "type" => "arithmetic",
+                 "fields" => [
+                   %{"fieldName" => "event_count", "type" => "fieldAccess"},
+                   %{"fieldName" => "foo_count", "type" => "fieldAccess"}
+                 ]
+               }
+             ]
+           } ==
+             decoded
   end
 
   test "join query" do
-    query = from %{
-      type: :join,
-      left: "my_datasource",
-      right: %{type: :lookup, lookup: "my_lookup"},
-      rightPrefix: "r.",
-      condition: "foo = \"r.k\"",
-      joinType: :inner
-    },
-      query_type: "topN",
-      intervals: ["2020-11-01/P7D"],
-      granularity: :day,
-      aggregations: [foo_count: count()],
-      dimension: "r.v",
-      metric: :foo_count,
-      threshold: 10
+    query =
+      from(
+        %{
+          type: :join,
+          left: "my_datasource",
+          right: %{type: :lookup, lookup: "my_lookup"},
+          rightPrefix: "r.",
+          condition: "foo = \"r.k\"",
+          joinType: :inner
+        },
+        query_type: "topN",
+        intervals: ["2020-11-01/P7D"],
+        granularity: :day,
+        aggregations: [foo_count: count()],
+        dimension: "r.v",
+        metric: :foo_count,
+        threshold: 10
+      )
+
     json = Panoramix.Query.to_json(query)
     assert is_binary(json)
     decoded = Jason.decode!(json)
-    assert %{"queryType" => "topN",
+
+    assert %{
+             "queryType" => "topN",
              "aggregations" => [%{"name" => "foo_count", "type" => "count"}],
              "context" => %{"priority" => 0, "timeout" => 120_000},
-             "dataSource" => %{"type" => "join",
-                               "joinType" => "inner",
-                               "left" => "my_datasource",
-                               "right" => %{"lookup" => "my_lookup", "type" => "lookup"},
-                               "rightPrefix" => "r.",
-                               "condition" => "foo = \"r.k\""},
+             "dataSource" => %{
+               "type" => "join",
+               "joinType" => "inner",
+               "left" => "my_datasource",
+               "right" => %{"lookup" => "my_lookup", "type" => "lookup"},
+               "rightPrefix" => "r.",
+               "condition" => "foo = \"r.k\""
+             },
              "dimension" => "r.v",
              "granularity" => "day",
              "intervals" => ["2020-11-01/P7D"],
              "metric" => "foo_count",
-             "threshold" => 10} == decoded
+             "threshold" => 10
+           } == decoded
   end
 end

--- a/test/panoramix_test.exs
+++ b/test/panoramix_test.exs
@@ -1351,4 +1351,21 @@ defmodule PanoramixTest do
              "threshold" => 10
            } == decoded
   end
+
+  test "subtotals spec" do
+    query =
+      from "table",
+        query_type: "groupBy",
+        subtotals_spec: [[:d1], [:d2, :d3]]
+
+    assert query.subtotals_spec
+
+    json = Panoramix.Query.to_json(query)
+
+    assert %{
+             "queryType" => "groupBy",
+             "context" => %{"priority" => 0, "timeout" => 120_000},
+             "subtotalsSpec" => [["d1"], ["d2", "d3"]]
+           } = Jason.decode!(json)
+  end
 end

--- a/test/panoramix_test.exs
+++ b/test/panoramix_test.exs
@@ -1368,4 +1368,30 @@ defmodule PanoramixTest do
              "subtotalsSpec" => [["d1"], ["d2", "d3"]]
            } = Jason.decode!(json)
   end
+
+  test "dynamic building of aggregations" do
+    aggregations = [
+      %{
+        type: "filtered",
+        filter: %{
+          type: "selector",
+          dimension: "dimension_id",
+          value: "value"
+        },
+        aggregator: %{
+          type: "longSum",
+          fieldName: "__count",
+          name: "dynamic_aggregator"
+        }
+      }
+    ]
+
+    query =
+      from "table",
+        query_type: "topN",
+        aggregations: ^aggregations,
+        dimension: :sum
+
+    assert ^aggregations = query.aggregations
+  end
 end


### PR DESCRIPTION
Hello, first off thanks for the library! We had a couple things come up that required workaround / converting to a map prior to requesting data from Druid.

Sorry I also ran `mix format` to normalize all the code, and also added the `from/2` macro to exported `locals_without_parens` so that formatting a project that isn't using Ecto doesn't wrap the macro in parentheses. 

### Aggregations 

Previously passing a variable to the `aggregations` key wasn't supported since `build_aggregations` always assumed it was a list literal. Similar to the `filters` option, you can now pass a variable for aggregations by using the `^` operator.

### SubtotalsSpec

We're using `subtotalsSpec` for queries pretty heavily and it was a bit clunky to run something this: `query |> Panoramix.Query.to_map() |> Map.put(:subtotalsSpec, subtotals)` vs just specifying it directly in the query.

Like I said, thank you! If you need anything else or need more context I'm happy to provide it.