### PR TITLE
Don't limit virtual column output types

### DIFF
--- a/lib/panoramix/query.ex
+++ b/lib/panoramix/query.ex
@@ -788,12 +788,7 @@ defmodule Panoramix.Query do
             expression: expression,
             output_type: output_type
           ] do
-      output_type = String.upcase(String.Chars.to_string(output_type))
-
-      unless output_type in ["LONG", "FLOAT", "DOUBLE", "STRING"] do
-        raise ArgumentError,
-              "Unexpected output type #{output_type}, expected one of :long, :float, :double, :string"
-      end
+      output_type = String.Chars.to_string(output_type)
 
       %{
         "type" => "expression",

--- a/test/panoramix_test.exs
+++ b/test/panoramix_test.exs
@@ -906,7 +906,7 @@ defmodule PanoramixTest do
                  "name" => "plus_one",
                  "type" => "expression",
                  "expression" => "foo + 1",
-                 "outputType" => "LONG"
+                 "outputType" => "long"
                }
              ],
              "aggregations" => [


### PR DESCRIPTION
As of Druid 24.0.0, virtual columns are no longer restricted to LONG, FLOAT, DOUBLE and STRING.

Also don't upcase the type name. For simple type names, Druid does that for us, and for complex type names, it's not necessarily appropriate.